### PR TITLE
theme-builder: reorder makeColors arguments and introduce tailwind submodule

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -26,6 +26,11 @@
       "types": "./dist/core.d.ts",
       "import": "./dist/core.mjs",
       "require": "./dist/core.cjs"
+    },
+    "./tailwind": {
+      "types": "./dist/tailwind.d.ts",
+      "import": "./dist/tailwind.mjs",
+      "require": "./dist/tailwind.cjs"
     }
   },
   "main": "./dist/index.mjs",
@@ -46,10 +51,12 @@
     "clean": "rm -rf dist node_modules"
   },
   "peerDependencies": {
-    "@material/material-color-utilities": "^0.3.0"
+    "@material/material-color-utilities": "^0.3.0",
+    "tailwindcss": "^3.4.15"
   },
   "dependencies": {
     "@material/material-color-utilities": "^0.3.0",
+    "tailwindcss": "^3.4.15",
     "type-fest": "^4.29.0"
   },
   "devDependencies": {

--- a/packages/theme-builder/src/colors.ts
+++ b/packages/theme-builder/src/colors.ts
@@ -88,9 +88,9 @@ export function makeCustomColors<Colors extends Record<string, ColorOption>>(sou
 }
 
 export function makeColors<CustomColors extends Record<string, ColorOption>>(source: Color,
+  customColors: CustomColors = {} as CustomColors,
   scheme: StandardDynamicSchemeKey = 'content',
   contrastLevel: number = 0,
-  customColors: CustomColors = {} as CustomColors,
 ) {
   source = hct(source);
 

--- a/packages/theme-builder/src/dynamic-color.ts
+++ b/packages/theme-builder/src/dynamic-color.ts
@@ -47,6 +47,20 @@ export const hexFromHct = (c: Hct) => hexFromArgb(argbFromHct(c));
 export const hctFromHex = (hex: string) => Hct.fromInt(argbFromHex(hex));
 export const hctFromArgb = (argb: number) => Hct.fromInt(argb);
 
+export const alphaFromArgb = (argb: number) => argb >> 24 & 255;
+export const redFromArgb = (argb: number) => argb >> 16 & 255;
+export const greenFromArgb = (argb: number) => argb >> 8 & 255;
+export const blueFromArgb = (argb: number) => argb & 255;
+
+export const rgbFromArgb = (argb: number) => {
+  const r = redFromArgb(argb);
+  const g = greenFromArgb(argb);
+  const b = blueFromArgb(argb);
+  return `${r} ${g} ${b}`;
+};
+
+export const rgbFromHct = (c: Hct) => rgbFromArgb(argbFromHct(c));
+
 export const hct = (value: string | Hct | number): Hct => {
   if (typeof value === 'object')
     return value;

--- a/packages/theme-builder/src/tailwind.test.ts
+++ b/packages/theme-builder/src/tailwind.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('dummy', () => {
+  expect(true).eq(true);
+});

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -1,0 +1,189 @@
+import plugin from 'tailwindcss/plugin';
+
+import {
+  makeColors,
+} from './colors';
+
+import type {
+  StandardDynamicSchemeKey,
+} from './colors-data';
+
+import {
+  Hct,
+  HexColor,
+  rgbFromHct,
+  hct,
+} from './dynamic-color';
+
+import type { CSSRuleObject, Config } from 'tailwindcss/types/config';
+
+import type { PropType } from './utils';
+
+// types
+//
+interface ColorConfig {
+  value: HexColor
+  harmonize?: boolean // default: true
+}
+
+interface MaterialColorConfig {
+  primary: HexColor | ColorConfig
+  [name: string]: HexColor | ColorConfig
+}
+
+export interface MaterialColorOptions {
+  scheme?: StandardDynamicSchemeKey // default: 'content'
+  contrastLevel?: number // default: 0
+  prefix?: string // default: 'md-'
+  darkSuffix?: string // default: '-dark'
+  lightSuffix?: string // default: '-light'
+  darkMode?: string // default: '.dark'
+};
+
+function defaultsMaterialColorOptions(options: MaterialColorOptions): MaterialColorOptions {
+  return {
+    scheme: 'content',
+    contrastLevel: 0,
+    prefix: 'md-',
+    darkSuffix: '-dark',
+    lightSuffix: '-light',
+    darkMode: '.dark',
+    ...options,
+  };
+}
+
+// helpers
+//
+interface TColorData {
+  value: Hct
+  harmonize: boolean
+}
+
+function flattenColorConfig(c: HexColor | ColorConfig): TColorData {
+  if (typeof c !== 'string') return {
+    value: hct(c.value),
+    harmonize: c.harmonize === undefined ? true : c.harmonize,
+  };
+
+  return {
+    value: hct(c),
+    harmonize: true,
+  };
+}
+
+function flattenColorConfigTable(colors: { [name: string]: HexColor | ColorConfig }) {
+  const out: Partial<{
+    [K in keyof typeof colors]: TColorData
+  }> = {};
+
+  for (const [name, value] of Object.entries(colors)) {
+    out[name] = flattenColorConfig(value);
+  }
+
+  return out as {
+    [K in keyof typeof colors]: TColorData
+  };
+}
+
+type colorMap<K extends string> = Record<K, Hct>;
+function buildTailwindConfig<K extends string>(dark: colorMap<K>, light: colorMap<K>, options: MaterialColorOptions) {
+  // apply defaults
+  options = defaultsMaterialColorOptions(options);
+
+  const keys = Object.keys(dark) as K[];
+  const rootVars: CSSRuleObject = {};
+  const darkVars: CSSRuleObject = {};
+  const colors: Record<string, string> = {};
+
+  const { prefix, darkSuffix, lightSuffix } = options;
+
+  for (const k of keys) {
+    const k0 = `--${prefix}${k}`;
+    const v1 = rgbFromHct(light[k]);
+    const v2 = rgbFromHct(dark[k]);
+
+    if (darkSuffix === '' && lightSuffix === '') {
+      // MODE 1: direct rgb.
+      rootVars[k0] = v1;
+      darkVars[k0] = v2;
+    } else if (darkSuffix !== '' && lightSuffix !== '') {
+      // MODE 2: dark and light variables.
+      const k1 = `${k0}${lightSuffix}`;
+      const k2 = `${k0}${darkSuffix}`;
+
+      rootVars[k1] = v1;
+      rootVars[k2] = v2;
+      rootVars[k0] = `var(${k1})`;
+      darkVars[k0] = `var(${k2})`;
+    } else if (darkSuffix === '') {
+      // MODE 4: dark direct, light variable.
+      const k1 = `${k0}${lightSuffix}`;
+
+      rootVars[k1] = v1;
+      rootVars[k0] = `var(${k1})`;
+      darkVars[k0] = v2;
+    } else {
+      // MODE 3: dark variables, light direct.
+      const k2 = `${k0}${darkSuffix}`;
+
+      rootVars[k0] = v1;
+      rootVars[k2] = v2;
+      darkVars[k0] = `var(${k2})`;
+    }
+
+    // register colors
+    colors[k] = `rgb(var(${k0}) / <alpha-value>)`;
+  }
+
+  // assemble return values
+  const styles: CSSRuleObject = {
+    ':root': rootVars,
+    [options?.darkMode || '.dark']: darkVars,
+  };
+
+  const theme: PropType<Config, 'theme'> = {
+    extend: {
+      colors,
+    },
+  };
+
+  return { styles, theme };
+}
+
+export function withMaterialColors(config: Partial<Config>,
+  colors: MaterialColorConfig,
+  options: MaterialColorOptions = {},
+): Partial<Config> {
+  // build themes
+  const { primary, ...extraColors } = { ...colors };
+  const source = flattenColorConfig(primary);
+  const customColors = flattenColorConfigTable(extraColors);
+
+  options = defaultsMaterialColorOptions(options);
+
+  // build
+  const { dark, light } = makeColors(source.value, customColors, options.scheme, options.contrastLevel);
+
+  type K = keyof typeof dark;
+  const { styles, theme } = buildTailwindConfig<K>(dark, light, options);
+
+  return <Partial<Config>>{
+    ...config,
+    theme: {
+      ...config?.theme,
+      ...theme,
+      extend: {
+        ...config?.theme?.extend,
+        ...theme?.extend,
+        colors: {
+          ...config?.theme?.extend?.colors,
+          ...theme?.extend?.colors,
+        },
+      },
+    },
+    plugins: [
+      ...(config.plugins || []),
+      plugin(({ addBase }) => addBase(styles)),
+    ],
+  };
+}

--- a/packages/theme-builder/src/utils.ts
+++ b/packages/theme-builder/src/utils.ts
@@ -4,6 +4,8 @@ export type Prettify<T> = {
   [K in keyof T]: T[K];
 };
 
+export type PropType<T, K extends keyof T> = T[K];
+
 export function kebabCase(s: string): string {
   return s.replace(/([a-z])([A-Z])/g, '$1-$2')
     .replace(/[\s_]+/g, '-')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@material/material-color-utilities':
         specifier: ^0.3.0
         version: 0.3.0
+      tailwindcss:
+        specifier: ^3.4.15
+        version: 3.4.15
       type-fest:
         specifier: ^4.29.0
         version: 4.29.0
@@ -159,6 +162,10 @@ importers:
         version: 2.1.6(@types/node@22.10.0)(jiti@2.4.0)(jsdom@25.0.1)(terser@5.36.0)(yaml@2.5.1)
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1769,6 +1776,9 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -1792,6 +1802,9 @@ packages:
     resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
     engines: {node: '>=10'}
     deprecated: This package is no longer supported.
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1906,6 +1919,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
@@ -2012,6 +2029,10 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -2271,6 +2292,9 @@ packages:
   devalue@5.1.1:
     resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
 
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
@@ -2278,6 +2302,9 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -3096,6 +3123,10 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+    engines: {node: '>=10'}
+
   lilconfig@3.1.2:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
     engines: {node: '>=14'}
@@ -3301,6 +3332,9 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3427,6 +3461,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
@@ -3585,6 +3623,14 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pirates@4.0.6:
+    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
+    engines: {node: '>= 6'}
+
   pkg-types@1.2.1:
     resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
 
@@ -3633,6 +3679,30 @@ packages:
     engines: {node: ^18.12.0 || ^20.9.0 || >=22.0}
     peerDependencies:
       postcss: ^8.4.31
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.0.1:
+    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@4.0.2:
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
 
   postcss-merge-longhand@7.0.4:
     resolution: {integrity: sha512-zer1KoZA54Q8RVHKOY5vMke0cCdNxMP3KBfDerjH/BYHh4nCIh+1Yy0t1pAEQF18ac/4z3OFclO+ZVH8azjR4A==}
@@ -3818,6 +3888,9 @@ packages:
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
   read-package-json-fast@4.0.0:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
@@ -4148,6 +4221,11 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
+  sucrase@3.35.0:
+    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   superjson@2.2.1:
     resolution: {integrity: sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==}
     engines: {node: '>=16'}
@@ -4183,6 +4261,11 @@ packages:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
 
+  tailwindcss@3.4.15:
+    resolution: {integrity: sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -4201,6 +4284,13 @@ packages:
 
   text-decoder@1.2.1:
     resolution: {integrity: sha512-x9v3H/lTKIJKQQe7RPQkLfKAnc9lUTkWDypIQgTzPJAq+5/GCDHonmshfvlsNSj58yyshbIJJDLmU15qNERrXQ==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -4262,6 +4352,9 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   tsconfck@3.1.3:
     resolution: {integrity: sha512-ulNZP1SVpRDesxeMLON/LtWM8HIgAJEIVpVVhBM6gsmvQ8+Rh+ZG7FWGvHh7Ah3pRABwVJWklWCr/BTZSv0xnQ==}
@@ -4813,6 +4906,8 @@ packages:
     engines: {node: '>= 14'}
 
 snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -6621,6 +6716,8 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -6654,6 +6751,8 @@ snapshots:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -6777,6 +6876,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-css@2.0.1: {}
+
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.24.2
@@ -6895,6 +6996,8 @@ snapshots:
   commander@10.0.1: {}
 
   commander@2.20.3: {}
+
+  commander@4.1.1: {}
 
   commander@7.2.0: {}
 
@@ -7108,11 +7211,15 @@ snapshots:
 
   devalue@5.1.1: {}
 
+  didyoumean@1.2.2: {}
+
   diff@7.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dlv@1.1.3: {}
 
   doctrine@3.0.0:
     dependencies:
@@ -8118,6 +8225,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lilconfig@2.1.0: {}
+
   lilconfig@3.1.2: {}
 
   lines-and-columns@1.2.4: {}
@@ -8324,6 +8433,12 @@ snapshots:
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.8: {}
 
@@ -8620,6 +8735,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   ofetch@1.4.1:
     dependencies:
       destr: 2.0.3
@@ -8781,6 +8898,10 @@ snapshots:
 
   pidtree@0.6.0: {}
 
+  pify@2.3.0: {}
+
+  pirates@4.0.6: {}
+
   pkg-types@1.2.1:
     dependencies:
       confbox: 0.1.8
@@ -8824,6 +8945,25 @@ snapshots:
 
   postcss-discard-overridden@7.0.0(postcss@8.4.49):
     dependencies:
+      postcss: 8.4.49
+
+  postcss-import@15.1.0(postcss@8.4.49):
+    dependencies:
+      postcss: 8.4.49
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.8
+
+  postcss-js@4.0.1(postcss@8.4.49):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.49
+
+  postcss-load-config@4.0.2(postcss@8.4.49):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.5.1
+    optionalDependencies:
       postcss: 8.4.49
 
   postcss-merge-longhand@7.0.4(postcss@8.4.49):
@@ -8991,6 +9131,10 @@ snapshots:
     dependencies:
       defu: 6.1.4
       destr: 2.0.3
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
 
   read-package-json-fast@4.0.0:
     dependencies:
@@ -9345,6 +9489,16 @@ snapshots:
       postcss: 8.4.49
       postcss-selector-parser: 6.1.2
 
+  sucrase@3.35.0:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      commander: 4.1.1
+      glob: 10.4.5
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.6
+      ts-interface-checker: 0.1.13
+
   superjson@2.2.1:
     dependencies:
       copy-anything: 3.0.5
@@ -9378,6 +9532,33 @@ snapshots:
 
   system-architecture@0.1.0: {}
 
+  tailwindcss@3.4.15:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.6
+      lilconfig: 2.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.4.49
+      postcss-import: 15.1.0(postcss@8.4.49)
+      postcss-js: 4.0.1(postcss@8.4.49)
+      postcss-load-config: 4.0.2(postcss@8.4.49)
+      postcss-nested: 6.2.0(postcss@8.4.49)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
   tapable@2.2.1: {}
 
   tar-stream@3.1.7:
@@ -9403,6 +9584,14 @@ snapshots:
       source-map-support: 0.5.21
 
   text-decoder@1.2.1: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   tiny-invariant@1.3.3: {}
 
@@ -9452,6 +9641,8 @@ snapshots:
   ts-api-utils@1.4.2(typescript@5.7.2):
     dependencies:
       typescript: 5.7.2
+
+  ts-interface-checker@0.1.13: {}
 
   tsconfck@3.1.3(typescript@5.7.2):
     optionalDependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced Tailwind CSS plugin for integrating material design color schemes.
	- Added functions for extracting ARGB color components and converting ARGB to RGB.
	- Enhanced color manipulation capabilities with new type definitions and helper functions.

- **Bug Fixes**
	- Updated parameter order in the `makeColors` function for improved clarity.

- **Tests**
	- Added a basic test to validate the testing setup.

- **Chores**
	- Updated package dependencies to include Tailwind CSS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->