### PR TITLE
github: build: allow install with frozen lockfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - name: pnpm install
-        run: pnpm -r i
+        run: pnpm -r i --no-frozen-lockfile
       - name: pnpm lint
         run: pnpm lint
       - name: pnpm build


### PR DESCRIPTION
to cope with the eslint-config submodule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the build process with updated dependency installation settings.
	- Maintained existing steps for repository checkout, Node.js setup, caching, and linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->