### PR TITLE
packages: replace `@poupe/eslint-config` link a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - name: pnpm install
-        run: pnpm -r i --no-frozen-lockfile
+        run: pnpm -r i
       - name: pnpm lint
         run: pnpm lint
       - name: pnpm build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "packages/eslint-config"]
-	path = packages/eslint-config
-	url = ../eslint-config
-	branch = main

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,24 @@ import { defineConfig } from '@poupe/eslint-config';
 
 export default defineConfig({
   rules: {
-    '@stylistic/semi': ['error', 'always'],
+    'unicorn/prevent-abbreviations': [
+      'error',
+      {
+        replacements: {
+          env: {
+            environment: false,
+          },
+          fn: {
+            function: false,
+          },
+          prop: {
+            property: false,
+          },
+          vars: {
+            variables: false,
+          },
+        },
+      },
+    ],
   },
 });

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "lint": "env DEBUG=eslint:eslint eslint --fix --ignore-pattern 'packages/*' . && pnpm -r lint",
     "prepare": "pnpm -r dev:prepare"
   },
+  "devDependencies": {
+    "@poupe/eslint-config": "^0.4.4"
+  },
   "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab"
 }

--- a/packages/poupe-nuxt/eslint.config.mjs
+++ b/packages/poupe-nuxt/eslint.config.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import { createConfigForNuxt } from '@nuxt/eslint-config/flat';
-import { files, rules } from '@poupe/eslint-config';
+import { forNuxt } from '@poupe/eslint-config/nuxt';
 
 // Run `pnpx @eslint/config-inspector` to inspect the resolved config interactively
 export default createConfigForNuxt({
@@ -15,11 +15,4 @@ export default createConfigForNuxt({
       './playground',
     ],
   },
-})
-  .append({
-    files,
-    rules: {
-      ...rules,
-      '@stylistic/semi': ['error', 'always'],
-    },
-  });
+}, forNuxt());

--- a/packages/poupe-nuxt/package.json
+++ b/packages/poupe-nuxt/package.json
@@ -35,7 +35,7 @@
     "@nuxt/module-builder": "^0.8.4",
     "@nuxt/schema": "^3.14.1592",
     "@nuxt/test-utils": "^3.14.4",
-    "@poupe/eslint-config": "link:../eslint-config",
+    "@poupe/eslint-config": "^0.4.4",
     "@types/node": "^22.10.0",
     "changelogen": "^0.5.7",
     "eslint": "^9.15.0",

--- a/packages/poupe-vue/package.json
+++ b/packages/poupe-vue/package.json
@@ -15,7 +15,7 @@
     "vue": "^3.5.10"
   },
   "devDependencies": {
-    "@poupe/eslint-config": "link:../eslint-config",
+    "@poupe/eslint-config": "^0.4.4",
     "@tsconfig/node20": "^20.1.4",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.10.0",

--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -60,7 +60,7 @@
     "type-fest": "^4.29.0"
   },
   "devDependencies": {
-    "@poupe/eslint-config": "link:../eslint-config",
+    "@poupe/eslint-config": "^0.4.4",
     "typescript": "~5.5.4",
     "vitest": "^2.1.6"
   },

--- a/packages/theme-builder/src/utils.ts
+++ b/packages/theme-builder/src/utils.ts
@@ -7,7 +7,7 @@ export type Prettify<T> = {
 export type PropType<T, K extends keyof T> = T[K];
 
 export function kebabCase(s: string): string {
-  return s.replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/[\s_]+/g, '-')
+  return s.replaceAll(/([a-z])([A-Z])/g, '$1-$2')
+    .replaceAll(/[\s_]+/g, '-')
     .toLowerCase();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@poupe/eslint-config':
+        specifier: ^0.4.4
+        version: 0.4.4(@eslint/js@9.16.0)(@stylistic/eslint-plugin@2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(@vue/eslint-config-typescript@14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-unicorn@56.0.1(eslint@9.15.0(jiti@2.4.0)))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript-eslint@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))
 
   packages/poupe-nuxt:
     devDependencies:
@@ -29,8 +33,8 @@ importers:
         specifier: ^3.14.4
         version: 3.14.4(@vue/test-utils@2.4.6)(h3@1.13.0)(jsdom@25.0.1)(magicast@0.3.5)(nitropack@2.10.4(typescript@5.7.2))(rollup@4.27.4)(vite@6.0.1(@types/node@22.10.0)(jiti@2.4.0)(terser@5.36.0)(yaml@2.5.1))(vitest@2.1.6(@types/node@22.10.0)(jiti@2.4.0)(jsdom@25.0.1)(terser@5.36.0)(yaml@2.5.1))(vue-router@4.4.5(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
       '@poupe/eslint-config':
-        specifier: link:../eslint-config
-        version: link:../eslint-config
+        specifier: ^0.4.4
+        version: 0.4.4(@eslint/js@9.16.0)(@stylistic/eslint-plugin@2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(@vue/eslint-config-typescript@14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-unicorn@56.0.1(eslint@9.15.0(jiti@2.4.0)))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript-eslint@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))
       '@types/node':
         specifier: ^22.10.0
         version: 22.10.0
@@ -60,8 +64,8 @@ importers:
         version: 3.5.13(typescript@5.5.4)
     devDependencies:
       '@poupe/eslint-config':
-        specifier: link:../eslint-config
-        version: link:../eslint-config
+        specifier: ^0.4.4
+        version: 0.4.4(@eslint/js@9.16.0)(@stylistic/eslint-plugin@2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(@vue/eslint-config-typescript@14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-plugin-unicorn@56.0.1(eslint@9.15.0(jiti@2.4.0)))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript-eslint@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))
       '@tsconfig/node20':
         specifier: ^20.1.4
         version: 20.1.4
@@ -127,8 +131,8 @@ importers:
         version: 4.29.0
     devDependencies:
       '@poupe/eslint-config':
-        specifier: link:../eslint-config
-        version: link:../eslint-config
+        specifier: ^0.4.4
+        version: 0.4.4(@eslint/js@9.16.0)(@stylistic/eslint-plugin@2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(@vue/eslint-config-typescript@14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-plugin-unicorn@56.0.1(eslint@9.15.0(jiti@2.4.0)))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript-eslint@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
@@ -905,6 +909,10 @@ packages:
     resolution: {integrity: sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/js@9.16.0':
+    resolution: {integrity: sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/object-schema@2.1.4':
     resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1197,6 +1205,19 @@ packages:
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
+
+  '@poupe/eslint-config@0.4.4':
+    resolution: {integrity: sha512-wtciUK2RQQLombWKxMrpyCX5YaXUQwAn+o8xwPFyiHVcy2V2sj4mU6ci34QQlTXbhi9aCUsFb7NvPw8/93mntg==}
+    engines: {node: '>= 18', pnpm: '>= 8'}
+    peerDependencies:
+      '@eslint/js': ^9.16.0
+      '@stylistic/eslint-plugin': ^2.11.0
+      '@typescript-eslint/parser': ^8.16.0
+      '@vue/eslint-config-typescript': ^14.1.4
+      eslint: ^9.15.0
+      eslint-plugin-unicorn: ^56.0.1
+      eslint-plugin-vue: ^9.31.0
+      typescript-eslint: ^8.16.0
 
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
@@ -5421,6 +5442,8 @@ snapshots:
 
   '@eslint/js@9.15.0': {}
 
+  '@eslint/js@9.16.0': {}
+
   '@eslint/object-schema@2.1.4': {}
 
   '@eslint/plugin-kit@0.2.3':
@@ -5598,7 +5621,7 @@ snapshots:
     dependencies:
       '@antfu/install-pkg': 0.4.1
       '@clack/prompts': 0.8.2
-      '@eslint/js': 9.15.0
+      '@eslint/js': 9.16.0
       '@nuxt/eslint-plugin': 0.7.2(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
       '@stylistic/eslint-plugin': 2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
       '@typescript-eslint/eslint-plugin': 8.16.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
@@ -5896,6 +5919,28 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
+  '@poupe/eslint-config@0.4.4(@eslint/js@9.16.0)(@stylistic/eslint-plugin@2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(@vue/eslint-config-typescript@14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-plugin-unicorn@56.0.1(eslint@9.15.0(jiti@2.4.0)))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript-eslint@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))':
+    dependencies:
+      '@eslint/js': 9.16.0
+      '@stylistic/eslint-plugin': 2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4)
+      '@vue/eslint-config-typescript': 14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4)
+      eslint: 9.15.0(jiti@2.4.0)
+      eslint-plugin-unicorn: 56.0.1(eslint@9.15.0(jiti@2.4.0))
+      eslint-plugin-vue: 9.31.0(eslint@9.15.0(jiti@2.4.0))
+      typescript-eslint: 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4)
+
+  '@poupe/eslint-config@0.4.4(@eslint/js@9.16.0)(@stylistic/eslint-plugin@2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(@vue/eslint-config-typescript@14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-unicorn@56.0.1(eslint@9.15.0(jiti@2.4.0)))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript-eslint@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))':
+    dependencies:
+      '@eslint/js': 9.16.0
+      '@stylistic/eslint-plugin': 2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+      '@vue/eslint-config-typescript': 14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+      eslint: 9.15.0(jiti@2.4.0)
+      eslint-plugin-unicorn: 56.0.1(eslint@9.15.0(jiti@2.4.0))
+      eslint-plugin-vue: 9.31.0(eslint@9.15.0(jiti@2.4.0))
+      typescript-eslint: 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+
   '@redocly/ajv@8.11.2':
     dependencies:
       fast-deep-equal: 3.1.3
@@ -6091,6 +6136,18 @@ snapshots:
     optional: true
 
   '@sindresorhus/merge-streams@2.3.0': {}
+
+  '@stylistic/eslint-plugin@2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4)':
+    dependencies:
+      '@typescript-eslint/utils': 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4)
+      eslint: 9.15.0(jiti@2.4.0)
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      estraverse: 5.3.0
+      picomatch: 4.0.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   '@stylistic/eslint-plugin@2.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)':
     dependencies:
@@ -6546,6 +6603,20 @@ snapshots:
       vue-eslint-parser: 9.4.3(eslint@9.15.0(jiti@2.4.0))
     optionalDependencies:
       typescript: 5.5.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - supports-color
+
+  '@vue/eslint-config-typescript@14.1.4(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint-plugin-vue@9.31.0(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)':
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.16.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+      eslint: 9.15.0(jiti@2.4.0)
+      eslint-plugin-vue: 9.31.0(eslint@9.15.0(jiti@2.4.0))
+      fast-glob: 3.3.2
+      typescript-eslint: 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+      vue-eslint-parser: 9.4.3(eslint@9.15.0(jiti@2.4.0))
+    optionalDependencies:
+      typescript: 5.7.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - supports-color
@@ -7369,7 +7440,7 @@ snapshots:
 
   eslint-config-unjs@0.4.1(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4):
     dependencies:
-      '@eslint/js': 9.15.0
+      '@eslint/js': 9.16.0
       eslint: 9.15.0(jiti@2.4.0)
       eslint-plugin-markdown: 5.1.0(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-unicorn: 55.0.0(eslint@9.15.0(jiti@2.4.0))
@@ -9617,6 +9688,17 @@ snapshots:
       eslint: 9.15.0(jiti@2.4.0)
     optionalDependencies:
       typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.16.0(@typescript-eslint/parser@8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2))(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.16.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.7.2)
+      eslint: 9.15.0(jiti@2.4.0)
+    optionalDependencies:
+      typescript: 5.7.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced string manipulation in the theme builder with improved kebab case functionality, allowing for multiple replacements in a string.

- **Bug Fixes**
	- Updated ESLint configuration to prevent the use of abbreviations, improving code readability.

- **Chores**
	- Transitioned ESLint configuration dependencies from local links to versioned dependencies across multiple packages, ensuring consistent linting practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->