### PR TITLE
theme-builder: change rgbFromArgb/rgbFromHct to include `rgb(...)` for CSS friendliness 

### DIFF
--- a/packages/theme-builder/.vscode/settings.json
+++ b/packages/theme-builder/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "Argb"
+    ]
+}

--- a/packages/theme-builder/src/dynamic-color.ts
+++ b/packages/theme-builder/src/dynamic-color.ts
@@ -62,7 +62,7 @@ export const rgbFromArgb = (argb: number) => {
   const r = redFromArgb(argb);
   const g = greenFromArgb(argb);
   const b = blueFromArgb(argb);
-  return `${r} ${g} ${b}`;
+  return `rgb(${r} ${g} ${b})`;
 };
 
 export const rgbFromHct = (c: Hct) => rgbFromArgb(argbFromHct(c));

--- a/packages/theme-builder/src/tailwind-common.ts
+++ b/packages/theme-builder/src/tailwind-common.ts
@@ -1,0 +1,35 @@
+// imports
+//
+import {
+  Hct,
+
+  argbFromHct,
+  redFromArgb,
+  greenFromArgb,
+  blueFromArgb,
+} from './dynamic-color';
+
+// re-export
+//
+export {
+  type Color,
+  type HexColor,
+  Hct,
+
+  hct,
+  hexFromHct,
+} from './dynamic-color';
+
+// export
+//
+
+// rgbFromArgb for tailwindcss color variables.
+export const rgbFromArgb = (argb: number) => {
+  const r = redFromArgb(argb);
+  const g = greenFromArgb(argb);
+  const b = blueFromArgb(argb);
+  return `${r} ${g} ${b}`;
+};
+
+// rgbFromHct for tailwindcss color variables.
+export const rgbFromHct = (c: Hct) => rgbFromArgb(argbFromHct(c));

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -9,11 +9,12 @@ import type {
 } from './colors-data';
 
 import {
+  type HexColor,
   Hct,
-  HexColor,
+
   rgbFromHct,
   hct,
-} from './dynamic-color';
+} from './tailwind-common';
 
 import type { CSSRuleObject, Config, PluginCreator } from 'tailwindcss/types/config';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Chores**
  - Added custom spelling dictionary configuration in VS Code settings

- **New Features**
  - Enhanced color conversion functions for RGB and HCT color formats

- **Refactor**
  - Reorganized color-related type imports and exports in theme builder module
  - Updated HexColor type import source for consistency in color handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->