### PR TITLE
feat(theme-builder): introduce CSSRuleObject and the initial formatCSSRuleObjects()

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/core.ts
+++ b/packages/theme-builder/src/core.ts
@@ -14,6 +14,10 @@ import {
 // re-export
 //
 export {
+  type CSSRuleObject,
+} from './utils';
+
+export {
   type CustomColor,
   DynamicScheme,
   Hct,

--- a/packages/theme-builder/src/core.ts
+++ b/packages/theme-builder/src/core.ts
@@ -15,6 +15,8 @@ import {
 //
 export {
   type CSSRuleObject,
+
+  formatCSSRuleObjects,
 } from './utils';
 
 export {

--- a/packages/theme-builder/src/index.ts
+++ b/packages/theme-builder/src/index.ts
@@ -1,3 +1,7 @@
 export * from './core';
 export * from './dynamic-color';
 export * from './dynamic-color-data';
+
+export {
+  type CSSRuleObject,
+} from './utils';

--- a/packages/theme-builder/src/tailwind-config.ts
+++ b/packages/theme-builder/src/tailwind-config.ts
@@ -1,6 +1,11 @@
 import plugin from 'tailwindcss/plugin.js';
 
 import {
+  type CSSRuleObject,
+  type PropType,
+} from './utils';
+
+import {
   type HexColor,
   Hct,
 
@@ -19,9 +24,7 @@ import {
   rgbFromHct,
 } from './tailwind-common';
 
-import type { CSSRuleObject, Config, PluginCreator } from 'tailwindcss/types/config';
-
-import type { PropType } from './utils';
+import type { Config, PluginCreator } from 'tailwindcss/types/config';
 
 // types
 //

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -1,4 +1,8 @@
 export {
+  type CSSRuleObject,
+} from './utils';
+
+export {
   type Color,
   type HexColor,
   Hct,

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -1,5 +1,7 @@
 export {
   type CSSRuleObject,
+
+  formatCSSRuleObjects,
 } from './utils';
 
 export {

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -12,6 +12,10 @@ export {
 } from './core';
 
 export {
+  type StandardDynamicSchemeKey,
+} from './dynamic-color-data';
+
+export {
   rgbFromHct,
 } from './tailwind-common';
 

--- a/packages/theme-builder/src/utils.ts
+++ b/packages/theme-builder/src/utils.ts
@@ -18,3 +18,62 @@ export function kebabCase(s: string): string {
 export interface CSSRuleObject {
   [key: string]: null | string | string[] | CSSRuleObject
 };
+
+function formatCSSRuleObject(rule: CSSRuleObject, indent: string, newLine: string, prefix: string): string {
+  const out: string[] = [];
+  const nextPrefix = prefix + indent;
+
+  for (const key in rule) {
+    // TODO: validate key;
+    const value = rule[key];
+
+    if (typeof value === 'object') {
+      // nested CSSRuleObject
+      const s1 = formatCSSRuleObject(value as CSSRuleObject, indent, newLine, nextPrefix);
+      if (s1 !== '') {
+        out.push(`${prefix}${key} {${newLine}${s1}${newLine}${prefix}}`);
+      }
+    } else if (typeof value === 'string') {
+      // string
+      if (value !== '') {
+        out.push(`${prefix}${key}: ${value};`);
+      }
+    } else if (Array.isArray(value)) {
+      // string[]
+      const ss1 = value as string[];
+      const ss: string[] = [];
+      let s: string = '';
+
+      for (const s1 of ss1) {
+        if (s1 !== '') {
+          ss.push(s1);
+        }
+      }
+
+      if (ss.length > 1) {
+        s = ss.join(`;${newLine}${prefix}`);
+      }
+
+      if (s !== '') {
+        out.push(`${prefix}${key} {${newLine}${nextPrefix}${s};${newLine}${prefix}}`);
+      }
+    }
+  }
+  return out.join(newLine);
+}
+
+export function formatCSSRuleObjects(rules: CSSRuleObject | CSSRuleObject[], indent: string = '\t', newLine: string = '\n', prefix: string = ''): string {
+  if (Array.isArray(rules)) {
+    const out: string[] = [];
+
+    for (const rule of rules) {
+      const s = formatCSSRuleObject(rule, indent, newLine, prefix);
+      if (s !== '') {
+        out.push(s);
+      }
+    }
+    return out.join(newLine);
+  }
+
+  return formatCSSRuleObject(rules, indent, newLine, prefix);
+}

--- a/packages/theme-builder/src/utils.ts
+++ b/packages/theme-builder/src/utils.ts
@@ -11,3 +11,10 @@ export function kebabCase(s: string): string {
     .replaceAll(/[\s_]+/g, '-')
     .toLowerCase();
 }
+
+/*
+ * CSSRuleObject inspired by tailwindcss/types/config's
+ */
+export interface CSSRuleObject {
+  [key: string]: null | string | string[] | CSSRuleObject
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Version Update**
  - Bumped package version from `0.2.7` to `0.2.8`

- **New Features**
  - Added `CSSRuleObject` type and `formatCSSRuleObjects` utility function
  - Expanded module exports to include new type and utility functions

- **Improvements**
  - Enhanced type safety for Tailwind configuration handling
  - Improved CSS rule object formatting capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->