### PR TITLE
feat(theme-builder): implement makeCSSColors/assembleCSSColors

### DIFF
--- a/packages/theme-builder/src/core.ts
+++ b/packages/theme-builder/src/core.ts
@@ -35,6 +35,7 @@ export type standardDynamicSchemeFactory = (primary: Color, isDark: boolean, con
 //
 export type HexColor = `#${string}`;
 export type Color = Hct | HexColor | number;
+export type ColorMap<K extends string> = Record<K, Hct>;
 
 // tools
 //

--- a/packages/theme-builder/src/dynamic-color-css.ts
+++ b/packages/theme-builder/src/dynamic-color-css.ts
@@ -1,0 +1,74 @@
+import {
+  type Color,
+  type ColorMap,
+  CSSRuleObject,
+  type Hct,
+
+  rgbFromHct,
+} from './core';
+
+import {
+  type StandardDynamicSchemeKey,
+} from './dynamic-color-data';
+
+import {
+  type ColorOption,
+
+  makeColors,
+} from './dynamic-color';
+
+export interface CSSColorOptions {
+  prefix: string // default: 'md-'
+  darkSuffix: string // default: '-dark'
+  lightSuffix: string // default: '-light'
+  stringify: (c: Hct) => string // default: rgb('{r} {g} {b}')
+};
+
+export function assembleCSSColors<K extends string>(dark: ColorMap<K>, light: ColorMap<K>, options: Partial<CSSColorOptions> = {}) {
+  const keys = Object.keys(dark).filter((key): boolean => !key.endsWith('-palette-key')) as K[];
+  const { prefix, darkSuffix, lightSuffix, stringify } = {
+    prefix: 'md-',
+    darkSuffix: '-dark',
+    lightSuffix: '-light',
+    stringify: rgbFromHct,
+    ...options,
+  };
+
+  const darkValues: CSSRuleObject = {};
+  const lightValues: CSSRuleObject = {};
+  const darkVars: CSSRuleObject = {};
+  const lightVars: CSSRuleObject = {};
+  const vars: Record<K, string> = {} as Record<K, string>;
+
+  for (const k of keys) {
+    const k0 = `--${prefix}${k}`;
+    const k1 = `${k0}${darkSuffix}`;
+    const k2 = `${k0}${lightSuffix}`;
+    const v1 = stringify(dark[k]);
+    const v2 = stringify(light[k]);
+
+    darkValues[k1] = v1;
+    lightValues[k2] = v2;
+    vars[k] = k0;
+
+    if (k1 !== k0) {
+      darkVars[k0] = `var(${k1})`;
+    }
+
+    if (k2 !== k0) {
+      lightVars[k0] = `var(${k2})`;
+    }
+  }
+
+  return { vars, darkValues, lightValues, darkVars, lightVars };
+}
+
+export function makeCSSColors<CustomColors extends Record<string, ColorOption>>(primary: Color,
+  customColors: CustomColors = {} as CustomColors,
+  scheme: StandardDynamicSchemeKey = 'content',
+  contrastLevel: number = 0,
+  options: Partial<CSSColorOptions> = {},
+) {
+  const { dark, light } = makeColors(primary, customColors, scheme, contrastLevel);
+  return assembleCSSColors(dark, light, options);
+}

--- a/packages/theme-builder/src/index.ts
+++ b/packages/theme-builder/src/index.ts
@@ -1,7 +1,4 @@
 export * from './core';
 export * from './dynamic-color';
 export * from './dynamic-color-data';
-
-export {
-  type CSSRuleObject,
-} from './utils';
+export * from './dynamic-color-css';

--- a/packages/theme-builder/src/tailwind-config.ts
+++ b/packages/theme-builder/src/tailwind-config.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   type HexColor,
+  type ColorMap,
   Hct,
 
   hct,
@@ -28,8 +29,6 @@ import type { Config, PluginCreator } from 'tailwindcss/types/config';
 
 // types
 //
-type ColorMap<K extends string> = Record<K, Hct>;
-
 interface ColorConfig {
   value: HexColor
   harmonize?: boolean // default: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced color management with new type definitions and utility functions for dynamic theming
  - Added support for more flexible color configuration in theme builder

- **Improvements**
  - Refined color handling with new `ColorMap` and `CustomColorOption` types
  - Improved CSS color generation for dynamic themes
  - Updated type definitions for better type safety and flexibility

- **Changes**
  - Modified export structure in theme builder package
  - Updated color processing functions with more precise color option handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->