### PR TITLE
feat(theme-builder): replace makeColors() with makeTheme() and makeCSSTheme [BREAKING] 

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,11 @@
 // @ts-check
 import { defineConfig } from '@poupe/eslint-config';
+import tsdocPlugin from 'eslint-plugin-tsdoc';
 
 export default defineConfig({
+  plugins: {
+    tsdoc: tsdocPlugin,
+  },
   rules: {
     'unicorn/prevent-abbreviations': [
       'error',
@@ -22,5 +26,6 @@ export default defineConfig({
         },
       },
     ],
+    'tsdoc/syntax': 'warn',
   },
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "devDependencies": {
     "@poupe/eslint-config": "^0.4.5",
-    "eslint": "^9.17.0"
+    "eslint": "^9.17.0",
+    "eslint-plugin-tsdoc": "^0.4.0"
   },
   "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321"
 }

--- a/packages/theme-builder/src/core.ts
+++ b/packages/theme-builder/src/core.ts
@@ -80,26 +80,44 @@ export const rgbFromArgb = (argb: number) => {
 
 export const rgbFromHct = (c: Hct) => rgbFromArgb(argbFromHct(c));
 
+/**
+ * @param value - color to convert to Hct.
+ * @returns Hct representation of the given color.
+ */
 export const hct = (value: string | Hct | number): Hct => {
   if (value instanceof Hct) {
     return value;
-  } else if (typeof value === 'object') {
-    throw new TypeError('not Hct object');
+  } else if (typeof value === 'number') {
+    return hctFromArgb(value);
+  } else {
+    return hctFromHex(value);
   }
-
-  return typeof value === 'number' ? hctFromArgb(value) : hctFromHex(value);
 };
 
+/**
+ * @param value - color to convert to ARGB
+ * @returns ARGB representation of the given color.
+ */
 export const argb = (value: string | Hct | number): number => {
-  if (typeof value === 'number')
+  if (value instanceof Hct) {
+    return argbFromHct(value);
+  } else if (typeof value === 'number') {
     return value;
-
-  return typeof value === 'object' ? argbFromHct(value) : argbFromHex(value);
+  } else {
+    return argbFromHex(value);
+  }
 };
 
+/**
+ * @param value - color to convert to HexColor
+ * @returns HexColor representation of the given Color.
+ */
 export const hex = (value: string | Hct | number): HexColor => {
-  if (typeof value === 'number')
+  if (value instanceof Hct) {
+    return hexFromHct(value);
+  } else if (typeof value === 'number') {
     return hexFromArgb(value);
-
-  return typeof value === 'object' ? hexFromHct(value) : hexFromString(value);
+  } else {
+    return hexFromString(value);
+  }
 };

--- a/packages/theme-builder/src/dynamic-color-css.ts
+++ b/packages/theme-builder/src/dynamic-color-css.ts
@@ -1,7 +1,6 @@
 import {
-  type Color,
   type ColorMap,
-  CSSRuleObject,
+  type CSSRuleObject,
   type Hct,
 
   rgbFromHct,
@@ -12,19 +11,23 @@ import {
 } from './dynamic-color-data';
 
 import {
-  type ColorOption,
+  type ThemeColors,
 
-  makeColors,
-} from './dynamic-color';
+  makeTheme,
+} from './dynamic-theme';
 
-export interface CSSColorOptions {
-  prefix: string // default: 'md-'
-  darkSuffix: string // default: '-dark'
-  lightSuffix: string // default: '-light'
-  stringify: (c: Hct) => string // default: rgb('{r} {g} {b}')
+export interface CSSThemeOptions {
+  /** @defaultValue `'md-'` */
+  prefix: string
+  /** @defaultValue `'-dark'` */
+  darkSuffix: string
+  /** @defaultValue `'-light'` */
+  lightSuffix: string
+  /** @defaultValue `rgb('{r} {g} {b}')` */
+  stringify: (c: Hct) => string
 };
 
-export function assembleCSSColors<K extends string>(dark: ColorMap<K>, light: ColorMap<K>, options: Partial<CSSColorOptions> = {}) {
+export function assembleCSSColors<K extends string>(dark: ColorMap<K>, light: ColorMap<K>, options: Partial<CSSThemeOptions> = {}) {
   const keys = Object.keys(dark).filter((key): boolean => !key.endsWith('-palette-key')) as K[];
   const { prefix, darkSuffix, lightSuffix, stringify } = {
     prefix: 'md-',
@@ -63,12 +66,16 @@ export function assembleCSSColors<K extends string>(dark: ColorMap<K>, light: Co
   return { vars, darkValues, lightValues, darkVars, lightVars };
 }
 
-export function makeCSSColors<CustomColors extends Record<string, ColorOption>>(primary: Color,
-  customColors: CustomColors = {} as CustomColors,
-  scheme: StandardDynamicSchemeKey = 'content',
-  contrastLevel: number = 0,
-  options: Partial<CSSColorOptions> = {},
+export interface MakeCSSThemeOptions extends CSSThemeOptions {
+  /** default: 'content' */
+  scheme?: StandardDynamicSchemeKey
+  /** default: 0 */
+  contrastLevel?: number
+}
+
+export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
+  options: Partial<MakeCSSThemeOptions> = {},
 ) {
-  const { dark, light } = makeColors(primary, customColors, scheme, contrastLevel);
+  const { dark, light } = makeTheme(colors, options.scheme, options.contrastLevel);
   return assembleCSSColors(dark, light, options);
 }

--- a/packages/theme-builder/src/dynamic-color-css.ts
+++ b/packages/theme-builder/src/dynamic-color-css.ts
@@ -67,12 +67,19 @@ export function assembleCSSColors<K extends string>(dark: ColorMap<K>, light: Co
 }
 
 export interface MakeCSSThemeOptions extends CSSThemeOptions {
-  /** default: 'content' */
+  /** @defaultValue `'content'` */
   scheme?: StandardDynamicSchemeKey
-  /** default: 0 */
+  /** @defaultValue `0` */
   contrastLevel?: number
 }
 
+/**
+ *  makeCSSTheme assembles CSS variables to use in M3 dark/light themes.
+ *
+ * @param colors - base colors of the theme.
+ * @param options - configuration options.
+ * @returns  CSSRuleObjects to set up dark/light themes.
+ */
 export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
   options: Partial<MakeCSSThemeOptions> = {},
 ) {

--- a/packages/theme-builder/src/dynamic-theme.ts
+++ b/packages/theme-builder/src/dynamic-theme.ts
@@ -1,0 +1,88 @@
+import {
+  type Color,
+  type ColorMap,
+  hct,
+  Hct,
+} from './core';
+
+import {
+  type StandardDynamicSchemeKey,
+
+  standardDynamicSchemes,
+} from './dynamic-color-data';
+
+import {
+  type ColorOptions,
+
+  makeCustomColors,
+  makeStandardColorsFromScheme,
+} from './dynamic-color';
+
+/**
+ * ThemeColors describes colors used to build the theme.
+ */
+export type ThemeColors<K extends string> = { primary: Color | ColorOptions } & Record<K, Color | ColorOptions>;
+
+export type FlatThemeColors<K extends string> = { primary: ColorOptions } & Record<K, ColorOptions>;
+
+function flattenColorOptions(c: Color | ColorOptions): ColorOptions {
+  if (c instanceof Hct) {
+    return { value: c };
+  }
+  if (typeof c !== 'object') {
+    return { value: hct(c) };
+  }
+  return c;
+}
+
+export function flattenThemeColors<K extends string>(colors: ThemeColors<K>) {
+  const out = {} as Record<string, ColorOptions>;
+
+  for (const [name, value] of Object.entries(colors)) {
+    out[name] = flattenColorOptions(value);
+  }
+
+  return out as FlatThemeColors<K>;
+}
+
+/**
+ * @param colors - base colors of the theme.
+ * @param scheme - Material color scheme to use.
+ * @param contrastLevel - contrast level from -1 (minimum) to 1 (maximum). 0 represents standard.
+ * @returns dark and light themes.
+ */
+export function makeTheme<K extends string>(colors: ThemeColors<K>,
+  scheme: StandardDynamicSchemeKey = 'content',
+  contrastLevel: number = 0,
+) {
+  const { primary, ...extraColors } = flattenThemeColors(colors);
+  const source = primary.value as Hct;
+
+  const schemeFactory = standardDynamicSchemes[scheme] || standardDynamicSchemes.content;
+  const darkScheme = schemeFactory(source, true, contrastLevel);
+  const lightScheme = schemeFactory(source, false, contrastLevel);
+
+  const { dark: darkCustomColors, light: lightCustomColors } = makeCustomColors(source, extraColors);
+  const darkStandardColors = makeStandardColorsFromScheme(darkScheme);
+  const lightStandardColors = makeStandardColorsFromScheme(lightScheme);
+
+  type N = keyof typeof darkStandardColors & keyof typeof darkCustomColors;
+
+  const dark: ColorMap<N> = {
+    ...darkStandardColors,
+    ...darkCustomColors,
+  };
+
+  const light: ColorMap<N> = {
+    ...lightStandardColors,
+    ...lightCustomColors,
+  };
+
+  return {
+    source,
+    darkScheme,
+    lightScheme,
+    dark,
+    light,
+  };
+}

--- a/packages/theme-builder/src/index.ts
+++ b/packages/theme-builder/src/index.ts
@@ -2,3 +2,4 @@ export * from './core';
 export * from './dynamic-color';
 export * from './dynamic-color-data';
 export * from './dynamic-color-css';
+export * from './dynamic-theme';

--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -1,0 +1,31 @@
+import {
+  type MakeCSSThemeOptions,
+
+  assembleCSSColors,
+} from './dynamic-color-css';
+import {
+  type ThemeColors,
+
+  makeTheme,
+} from './dynamic-theme';
+
+import {
+  rgbFromHct,
+} from './tailwind-common';
+
+/**
+ *  makeCSSTheme assembles CSS variables to use in M3 dark/light TailwindCSS themes.
+ *
+ * @param colors - base colors of the theme.
+ * @param options - configuration options.
+ * @returns  CSSRuleObjects to set up dark/light themes.
+ */
+export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
+  options: Partial<MakeCSSThemeOptions> = {},
+) {
+  const { dark, light } = makeTheme(colors, options.scheme, options.contrastLevel);
+  return assembleCSSColors(dark, light, {
+    stringify: rgbFromHct,
+    ...options,
+  });
+}

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -22,16 +22,20 @@ export {
 } from './tailwind-common';
 
 export {
+  type Shades,
+
+  makeShades,
+  makeHexShades,
+} from './tailwind-shades';
+
+export {
+  makeCSSTheme,
+} from './tailwind-theme';
+
+export {
   type TailwindConfigOptions,
   type MaterialColorOptions,
 
   withMaterialColors,
   withPrintMode,
 } from './tailwind-config';
-
-export {
-  type Shades,
-
-  makeShades,
-  makeHexShades,
-} from './tailwind-shades';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       eslint:
         specifier: ^9.17.0
         version: 9.17.0(jiti@2.4.2)
+      eslint-plugin-tsdoc:
+        specifier: ^0.4.0
+        version: 0.4.0
 
   packages/poupe-nuxt:
     devDependencies:
@@ -1010,6 +1013,12 @@ packages:
   '@material/material-color-utilities@0.3.0':
     resolution: {integrity: sha512-ztmtTd6xwnuh2/xu+Vb01btgV8SQWYCaK56CkRK8gEkWe5TuDyBcYJ0wgkMRn+2VcE9KUmhvkz+N9GHrqw/C0g==}
 
+  '@microsoft/tsdoc-config@0.17.1':
+    resolution: {integrity: sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==}
+
+  '@microsoft/tsdoc@0.15.1':
+    resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
   '@netlify/functions@2.8.2':
     resolution: {integrity: sha512-DeoAQh8LuNPvBE4qsKlezjKj0PyXDryOFJfJKo3Z1qZLKzQ21sT314KQKPVjfvw6knqijj+IO+0kHXy/TJiqNA==}
     engines: {node: '>=14.0.0'}
@@ -1863,6 +1872,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
   alien-signals@0.4.12:
     resolution: {integrity: sha512-Og0PgAihxlp1R22bsoBsyhhMG4+qhU+fkkLPoGBQkYVc3qt9rYnrwYTf+M6kqUqUZpf3rXDnpL90iKa0QcSVVg==}
 
@@ -2594,6 +2606,9 @@ packages:
     peerDependencies:
       eslint: '>=8.44.0'
 
+  eslint-plugin-tsdoc@0.4.0:
+    resolution: {integrity: sha512-MT/8b4aKLdDClnS8mP3R/JNjg29i0Oyqd/0ym6NnQf+gfKbJJ4ZcSh2Bs1H0YiUMTBwww5JwXGTWot/RwyJ7aQ==}
+
   eslint-plugin-unicorn@56.0.1:
     resolution: {integrity: sha512-FwVV0Uwf8XPfVnKSGpMg7NtlZh0G0gBarCaFcMUOoqPxXryxdYxTRRv4kH6B9TFCVIrjRXG+emcxIk2ayZilog==}
     engines: {node: '>=18.18'}
@@ -3172,6 +3187,9 @@ packages:
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
   js-beautify@1.15.1:
     resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
@@ -5767,6 +5785,15 @@ snapshots:
 
   '@material/material-color-utilities@0.3.0': {}
 
+  '@microsoft/tsdoc-config@0.17.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      ajv: 8.12.0
+      jju: 1.4.0
+      resolve: 1.22.10
+
+  '@microsoft/tsdoc@0.15.1': {}
+
   '@netlify/functions@2.8.2':
     dependencies:
       '@netlify/serverless-functions-api': 1.26.1
@@ -6903,6 +6930,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.12.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
   alien-signals@0.4.12: {}
 
   ansi-colors@4.1.3: {}
@@ -7709,6 +7743,11 @@ snapshots:
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
+  eslint-plugin-tsdoc@0.4.0:
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+
   eslint-plugin-unicorn@56.0.1(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
@@ -8345,6 +8384,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.4.2: {}
+
+  jju@1.4.0: {}
 
   js-beautify@1.15.1:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced TypeScript documentation linting with new ESLint plugin
	- Improved color theme generation and management
	- New dynamic theming capabilities for color configurations

- **Improvements**
	- Refined color conversion and handling functions
	- Updated type definitions for better type safety
	- Streamlined theme generation process

- **Chores**
	- Updated development dependencies
	- Restructured theme-related modules for better maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->