### PR TITLE
feat(theme-builder): tailwind: reimplement withMaterialColors [BREAKING] 

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/dynamic-color-css.ts
+++ b/packages/theme-builder/src/dynamic-color-css.ts
@@ -39,9 +39,10 @@ export function assembleCSSColors<K extends string>(dark: ColorMap<K>, light: Co
 
   const darkValues: CSSRuleObject = {};
   const lightValues: CSSRuleObject = {};
-  const darkVars: CSSRuleObject = {};
-  const lightVars: CSSRuleObject = {};
   const vars: Record<K, string> = {} as Record<K, string>;
+
+  let darkVars: CSSRuleObject | undefined = {};
+  let lightVars: CSSRuleObject | undefined = {};
 
   for (const k of keys) {
     const k0 = `--${prefix}${k}`;
@@ -61,6 +62,13 @@ export function assembleCSSColors<K extends string>(dark: ColorMap<K>, light: Co
     if (k2 !== k0) {
       lightVars[k0] = `var(${k2})`;
     }
+  }
+
+  if (Object.keys(darkVars).length === 0) {
+    darkVars = undefined;
+  }
+  if (Object.keys(lightVars).length === 0) {
+    lightVars = undefined;
   }
 
   return { vars, darkValues, lightValues, darkVars, lightVars };

--- a/packages/theme-builder/src/dynamic-color-data.ts
+++ b/packages/theme-builder/src/dynamic-color-data.ts
@@ -32,6 +32,8 @@ export type CustomDynamicColorKey<T extends string> =
 
 // StandardDynamicColor
 //
+
+/** standardDynamicColors are all dynamic colors defined by Material Design 3 */
 export const standardDynamicColors = {
   // surface-{}
   'surface': MaterialDynamicColors.surface,
@@ -105,10 +107,16 @@ export const standardDynamicColors = {
   'scrim': MaterialDynamicColors.scrim,
 };
 
+/** contentAccentToneDelta is re-exported from MaterialDynamicColors for completeness */
 export const contentAccentToneDelta = MaterialDynamicColors.contentAccentToneDelta;
 
+/** StandardDynamicColorKey is a type representing all fields in standardDynamicColors */
 export type StandardDynamicColorKey = keyof typeof standardDynamicColors;
 
+/** standardDynamicColorKeys is an array of all StandardDynamicColorKey values */
+export const standardDynamicColorKeys = Object.keys(standardDynamicColors) as StandardDynamicColorKey[];
+
+/** standardPaletteKeyColors are all palette key colors defined by MaterialDynamicColors */
 export const standardPaletteKeyColors = {
   'primary': MaterialDynamicColors.primaryPaletteKeyColor,
   'secondary': MaterialDynamicColors.secondaryPaletteKeyColor,
@@ -117,8 +125,10 @@ export const standardPaletteKeyColors = {
   'neutral-variant': MaterialDynamicColors.neutralVariantPaletteKeyColor,
 };
 
+/** StandardPaletteKey is a type representing all palette key colors is standardPaletteKeyColors */
 export type StandardPaletteKey = keyof typeof standardPaletteKeyColors;
 
+/** standardPaletteKeys is an array of all StandardPaletteKey values */
 export const standardPaletteKeys = Object.keys(standardPaletteKeyColors) as StandardPaletteKey[];
 
 // DynamicScheme

--- a/packages/theme-builder/src/dynamic-color.ts
+++ b/packages/theme-builder/src/dynamic-color.ts
@@ -36,6 +36,9 @@ import {
 export interface ColorOptions {
   value: Color
 
+  /** name allows us to customize the tailwindcss color name */
+  name?: string
+
   /** harmonize indicates the value must be blended to the source color */
   harmonize?: boolean
 };

--- a/packages/theme-builder/src/dynamic-theme.ts
+++ b/packages/theme-builder/src/dynamic-theme.ts
@@ -19,28 +19,31 @@ import {
   makeStandardPaletteFromScheme,
 } from './dynamic-color';
 
+/** flattens ThemeColors */
+function flattenColorOptions(c: Color | ColorOptions): ColorOptions {
+  return c instanceof Hct || typeof c !== 'object' ? { value: c } : c;
+}
+
 /**
  * ThemeColors describes colors used to build the theme.
  */
 export type ThemeColors<K extends string> = { primary: Color | ColorOptions } & Record<K, Color | ColorOptions>;
 
+/**
+ * FlatThemeColors defines the colors of the theme
+ */
 export type FlatThemeColors<K extends string> = { primary: ColorOptions } & Record<K, ColorOptions>;
 
-function flattenColorOptions(c: Color | ColorOptions): ColorOptions {
-  if (c instanceof Hct || typeof c !== 'object') {
-    return { value: c };
-  }
-  return c;
-}
-
+/** flattens a ThemeColors */
 export function flattenThemeColors<K extends string>(colors: ThemeColors<K>) {
-  const out = {} as Record<string, ColorOptions>;
+  const out = {} as Record<keyof typeof colors, ColorOptions>;
+  const keys = Object.keys(colors) as Array<keyof typeof colors>;
 
-  for (const [name, value] of Object.entries(colors)) {
-    out[name] = flattenColorOptions(value);
+  for (const c of keys) {
+    out[c] = flattenColorOptions(colors[c]);
   }
 
-  return out as FlatThemeColors<K>;
+  return out;
 }
 
 /**

--- a/packages/theme-builder/src/dynamic-theme.ts
+++ b/packages/theme-builder/src/dynamic-theme.ts
@@ -1,4 +1,10 @@
 import {
+  type KebabCase,
+
+  kebabCase,
+} from './utils';
+
+import {
   type Color,
   Hct,
 
@@ -7,8 +13,14 @@ import {
 
 import {
   type StandardDynamicSchemeKey,
+  type CustomDynamicColorKey,
 
+  customDynamicColors,
+  standardDynamicColorKeys,
+  StandardDynamicColorKey,
   standardDynamicSchemes,
+  standardPaletteKeys,
+  StandardPaletteKey,
 } from './dynamic-color-data';
 
 import {
@@ -19,10 +31,26 @@ import {
   makeStandardPaletteFromScheme,
 } from './dynamic-color';
 
+/** flattens ThemeColorOptions or ThemeColors */
+function flattenPartialColorOptions(c?: Color | ColorOptions | Partial<ColorOptions>): Partial<ColorOptions> {
+  if (c === undefined) {
+    return {};
+  } else if (c instanceof Hct || typeof c !== 'object') {
+    return { value: c };
+  } else {
+    return c;
+  }
+}
+
 /** flattens ThemeColors */
 function flattenColorOptions(c: Color | ColorOptions): ColorOptions {
   return c instanceof Hct || typeof c !== 'object' ? { value: c } : c;
 }
+
+/**
+ * ThemeColorOptions defines the colors of the theme but without requiring any particular option
+ */
+export type ThemeColorOptions<K extends string> = { primary: Partial<ColorOptions> } & Record<K, Partial<ColorOptions>>;
 
 /**
  * ThemeColors describes colors used to build the theme.
@@ -33,6 +61,18 @@ export type ThemeColors<K extends string> = { primary: Color | ColorOptions } & 
  * FlatThemeColors defines the colors of the theme
  */
 export type FlatThemeColors<K extends string> = { primary: ColorOptions } & Record<K, ColorOptions>;
+
+/** flattens a ThemeColorOptions */
+export function flattenPartialThemeColors<K extends string>(colors: ThemeColorOptions<K> | ThemeColors<K>) {
+  const out = {} as Record<keyof typeof colors, Partial<ColorOptions>>;
+  const keys = Object.keys(colors) as Array<keyof typeof colors>;
+
+  for (const c of keys) {
+    out[c] = flattenPartialColorOptions(colors[c]);
+  }
+
+  return out;
+}
 
 /** flattens a ThemeColors */
 export function flattenThemeColors<K extends string>(colors: ThemeColors<K>) {
@@ -46,6 +86,50 @@ export function flattenThemeColors<K extends string>(colors: ThemeColors<K>) {
   return out;
 }
 
+/**
+ * makeThemeKeys returns the keys of makeTheme makes without calculating
+ * the values.
+ */
+export function makeThemeKeys<K extends string>(colors: ThemeColorOptions<K> | ThemeColors<K>) {
+  type PaletteKey = StandardPaletteKey | KebabCase<K>;
+  type ColorKey = PaletteKey | StandardDynamicColorKey | CustomDynamicColorKey<KebabCase<K>>;
+
+  const configOptions = {} as Record<PaletteKey, Partial<ColorOptions>>;
+  const paletteKeys: PaletteKey[] = [...standardPaletteKeys];
+  const keys: ColorKey[] = [...standardDynamicColorKeys];
+
+  const $colors = Object.keys(colors) as Array<keyof typeof colors>;
+  for (const name of $colors) {
+    const kebabName = kebabCase(name) as KebabCase<K>;
+
+    // preserve config
+    configOptions[kebabName] = flattenPartialColorOptions(colors[name]);
+
+    if (!(kebabName in keys)) {
+      // custom color
+      paletteKeys.push(kebabName);
+      for (const pattern in customDynamicColors) {
+        keys.push(pattern.replace('{}', kebabName) as CustomDynamicColorKey<KebabCase<K>>);
+      }
+    }
+  }
+
+  // additional standard palette colors
+  for (const name of standardPaletteKeys) {
+    if (!(name in keys)) {
+      keys.push(name);
+    }
+    if (!(name in configOptions)) {
+      configOptions[name] = {};
+    }
+  }
+
+  return {
+    keys,
+    paletteKeys,
+    configOptions,
+  };
+}
 /**
  * @param colors - base colors of the theme.
  * @param scheme - Material color scheme to use.

--- a/packages/theme-builder/src/tailwind-shades.ts
+++ b/packages/theme-builder/src/tailwind-shades.ts
@@ -26,16 +26,28 @@ export const defaultShades = [
   900,
 ];
 
-// Shades can be an array of numbers between 0 and 1000 where
-// 0 is full brightness and 1000 full darkness. if it's true,
-// the defaultShades will be used, and if false only the DEFAULT
-// entry will be set.
+/**
+ * Shades can be an array of numbers between 0 and 1000 where
+ * 0 is full brightness and 1000 full darkness. if it's true,
+ * the defaultShades will be used, and if false only the DEFAULT
+ * entry will be set.
+ */
 export type Shades = boolean | number[];
 
+/**
+ * Shade is a particular shade of a tailwind color
+ */
+export type Shade = number | 'DEFAULT';
+
+/**
+ * @param color - color to use as reference
+ * @param shades - list of shade values to use
+ * @returns colors based on the given reference with modified tone.
+ */
 export function makeShades(color: Color, shades: Shades = true) {
   const c1 = hct(color);
 
-  const out: Record<number | 'DEFAULT', Hct> = {
+  const out: Record<Shade, Hct> = {
     DEFAULT: c1,
   };
 

--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -10,8 +10,10 @@ import {
 
 import {
   type ThemeColors,
+  type ThemeColorOptions,
 
   makeTheme,
+  makeThemeKeys,
 } from './dynamic-theme';
 
 import {
@@ -19,6 +21,9 @@ import {
 } from './tailwind-common';
 
 import {
+  type Shade,
+
+  defaultShades,
   makeShades,
 } from './tailwind-shades';
 
@@ -64,4 +69,40 @@ export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
     stringify: rgbFromHct,
     ...options,
   });
+}
+
+/**
+ * @param colors - describes the colors of the theme.
+ * @param prefix - indicates the prefix used for the CSS variables.
+ * @returns tailwindcss Config theme colors using the CSS variables associated with the theme.
+ */
+export function makeColorConfig<K extends string>(colors: ThemeColorOptions<K> | ThemeColors<K>,
+  prefix: string = 'md-',
+) {
+  const { keys, paletteKeys } = makeThemeKeys(colors);
+  const theme = {} as Record<typeof keys[0] | typeof paletteKeys[0], string | Record<Shade, string>>;
+
+  // palette colors with shades
+  for (const color of paletteKeys) {
+    const k0 = `--${prefix}${color}`;
+    const colorShades = {} as Record<Shade, string>;
+
+    for (const shade of defaultShades) {
+      const k1 = `${k0}-${shade}`;
+      colorShades[shade] = `rgb(var(${k1}) / <alpha-value>)`;
+    }
+
+    colorShades['DEFAULT'] = `rgb(var(${k0}) / <alpha-value>)`;
+    theme[color] = colorShades;
+  }
+
+  // the rest directly
+  for (const color of keys) {
+    if (!(color in theme)) {
+      const k0 = `--${prefix}${color}`;
+      theme[color] = `rgb(var(${k0}) / <alpha-value>)`;
+    }
+  }
+
+  return theme;
 }

--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -1,4 +1,8 @@
 import {
+  type Prettify,
+} from './utils';
+
+import {
   Hct,
 } from './core';
 
@@ -79,12 +83,14 @@ export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
 export function makeColorConfig<K extends string>(colors: ThemeColorOptions<K> | ThemeColors<K>,
   prefix: string = 'md-',
 ) {
-  const { keys, paletteKeys } = makeThemeKeys(colors);
-  const theme = {} as Record<typeof keys[0] | typeof paletteKeys[0], string | Record<Shade, string>>;
+  const { keys, paletteKeys, configOptions } = makeThemeKeys(colors);
+  const theme = {} as Record<string, string | Record<Shade, string>>;
 
   // palette colors with shades
   for (const color of paletteKeys) {
     const k0 = `--${prefix}${color}`;
+    const colorName = configOptions[color]?.name || color;
+
     const colorShades = {} as Record<Shade, string>;
 
     for (const shade of defaultShades) {
@@ -93,7 +99,7 @@ export function makeColorConfig<K extends string>(colors: ThemeColorOptions<K> |
     }
 
     colorShades['DEFAULT'] = `rgb(var(${k0}) / <alpha-value>)`;
-    theme[color] = colorShades;
+    theme[colorName] = colorShades;
   }
 
   // the rest directly
@@ -104,5 +110,5 @@ export function makeColorConfig<K extends string>(colors: ThemeColorOptions<K> |
     }
   }
 
-  return theme;
+  return theme as Prettify<typeof theme>;
 }

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -35,9 +35,6 @@ export {
 } from './tailwind-theme';
 
 export {
-  type TailwindConfigOptions,
-  type MaterialColorOptions,
-
   withMaterialColors,
   withPrintMode,
 } from './tailwind-config';

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -22,6 +22,7 @@ export {
 } from './tailwind-common';
 
 export {
+  type Shade,
   type Shades,
 
   makeShades,

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -30,6 +30,7 @@ export {
 } from './tailwind-shades';
 
 export {
+  makeColorConfig,
   makeCSSTheme,
 } from './tailwind-theme';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Version Update**
	- Bumped `@poupe/theme-builder` package version from `0.3.0` to `0.3.1`

- **New Features**
	- Enhanced dynamic color management with new color constants and types
	- Added optional name property for color customization
	- Introduced new functions for improved theme color configuration and handling
	- Added `makeColorConfig` function for Tailwind CSS theme configuration

- **Refactor**
	- Streamlined Tailwind CSS color configuration functions
	- Improved type safety for color and theme management
	- Updated handling of CSS variables in dynamic color assembly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->