### PR TITLE
feat(theme-builder): optional ColorOptions.name, and makeTheme()/makeThemeKeys() to return colorOptions

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/dynamic-color.ts
+++ b/packages/theme-builder/src/dynamic-color.ts
@@ -37,11 +37,27 @@ export interface ColorOptions {
   value: Color
 
   /** name allows us to customize the tailwindcss color name */
-  name?: string
+  name?: boolean | string
 
   /** harmonize indicates the value must be blended to the source color */
   harmonize?: boolean
 };
+
+/**
+ * @param color - color name in the table
+ * @param colors - table of ColorOptions
+ * @returns desired name for the color. undefined if the color is to be omitted.
+ */
+export function getColorNameOption<K extends string>(color: K, colors: Record<K, Partial<ColorOptions>>): string | undefined {
+  const $opt = colors[color];
+  if ($opt === undefined || $opt.name === undefined || $opt.name === true) {
+    return color; // default
+  } else if ($opt.name !== false && $opt.name !== '') {
+    return $opt.name; // custom
+  } else {
+    return undefined; // omit
+  }
+}
 
 type StandardDynamicColors = { [K in StandardDynamicColorKey]: Hct };
 type StandardPaletteColors = { [K in StandardPaletteKey]: Hct };

--- a/packages/theme-builder/src/dynamic-theme.ts
+++ b/packages/theme-builder/src/dynamic-theme.ts
@@ -152,10 +152,15 @@ export function makeTheme<K extends string>(colors: ThemeColors<K>,
   const darkStandardColors = makeStandardColorsFromScheme(darkScheme);
   const lightStandardColors = makeStandardColorsFromScheme(lightScheme);
 
-  const { colors: customPaletteKeys, dark: darkCustomColors, light: lightCustomColors } = makeCustomColors(source, extraColors);
+  const { colors: customPaletteKeys, dark: darkCustomColors, light: lightCustomColors, colorOptions: customColorOptions } = makeCustomColors(source, extraColors);
 
   type ColorKey = keyof typeof darkPalette & keyof typeof darkStandardColors & keyof typeof darkCustomColors;
   type PaletteKey = keyof typeof darkPalette & typeof customPaletteKeys[0];
+
+  const colorOptions: { [P in PaletteKey]: ColorOptions } = {
+    primary,
+    ...customColorOptions,
+  };
 
   const dark: { [P in ColorKey]: Hct } = {
     ...darkPalette,
@@ -184,6 +189,7 @@ export function makeTheme<K extends string>(colors: ThemeColors<K>,
 
   return {
     source,
+    colorOptions,
     darkScheme,
     lightScheme,
     darkPalette: darkCustomPalette as { [P in PaletteKey]: Hct },

--- a/packages/theme-builder/src/dynamic-theme.ts
+++ b/packages/theme-builder/src/dynamic-theme.ts
@@ -94,7 +94,7 @@ export function makeThemeKeys<K extends string>(colors: ThemeColorOptions<K> | T
   type PaletteKey = StandardPaletteKey | KebabCase<K>;
   type ColorKey = PaletteKey | StandardDynamicColorKey | CustomDynamicColorKey<KebabCase<K>>;
 
-  const configOptions = {} as Record<PaletteKey, Partial<ColorOptions>>;
+  const colorOptions = {} as Record<PaletteKey, Partial<ColorOptions>>;
   const paletteKeys: PaletteKey[] = [...standardPaletteKeys];
   const keys: ColorKey[] = [...standardDynamicColorKeys];
 
@@ -103,7 +103,7 @@ export function makeThemeKeys<K extends string>(colors: ThemeColorOptions<K> | T
     const kebabName = kebabCase(name) as KebabCase<K>;
 
     // preserve config
-    configOptions[kebabName] = flattenPartialColorOptions(colors[name]);
+    colorOptions[kebabName] = flattenPartialColorOptions(colors[name]);
 
     if (!(kebabName in keys)) {
       // custom color
@@ -119,15 +119,15 @@ export function makeThemeKeys<K extends string>(colors: ThemeColorOptions<K> | T
     if (!(name in keys)) {
       keys.push(name);
     }
-    if (!(name in configOptions)) {
-      configOptions[name] = {};
+    if (!(name in colorOptions)) {
+      colorOptions[name] = {};
     }
   }
 
   return {
     keys,
     paletteKeys,
-    configOptions,
+    colorOptions,
   };
 }
 /**

--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -87,12 +87,12 @@ export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
 export function makeColorConfig<K extends string>(colors: ThemeColorOptions<K> | ThemeColors<K>,
   prefix: string = 'md-',
 ) {
-  const { keys, paletteKeys, configOptions } = makeThemeKeys(colors);
+  const { keys, paletteKeys, colorOptions } = makeThemeKeys(colors);
   const theme = {} as Record<string, string | Record<Shade, string>>;
 
   // palette colors with shades
   for (const color of paletteKeys) {
-    const colorName = getColorNameOption(color, configOptions);
+    const colorName = getColorNameOption(color, colorOptions);
 
     if (colorName === undefined)
       continue;

--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -7,6 +7,10 @@ import {
 } from './core';
 
 import {
+  getColorNameOption,
+} from './dynamic-color';
+
+import {
   type MakeCSSThemeOptions,
 
   assembleCSSColors,
@@ -88,9 +92,12 @@ export function makeColorConfig<K extends string>(colors: ThemeColorOptions<K> |
 
   // palette colors with shades
   for (const color of paletteKeys) {
-    const k0 = `--${prefix}${color}`;
-    const colorName = configOptions[color]?.name || color;
+    const colorName = getColorNameOption(color, configOptions);
 
+    if (colorName === undefined)
+      continue;
+
+    const k0 = `--${prefix}${color}`;
     const colorShades = {} as Record<Shade, string>;
 
     for (const shade of defaultShades) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced color naming flexibility in theme builder.
	- Added a new function for retrieving color names based on options.

- **Refactor**
	- Streamlined color options processing.
	- Renamed configuration variables for clarity.
	- Updated theme generation logic to support more flexible color configurations.
	- Introduced a new property for color options in theme generation.

- **Bug Fixes**
	- Improved color name resolution mechanism.

- **Chores**
	- Updated package version to 0.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->