### PR TITLE
feat(theme-builder): tailwind: allow shades customisation and add 950 to the default list

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/tailwind-config.ts
+++ b/packages/theme-builder/src/tailwind-config.ts
@@ -19,15 +19,15 @@ import {
 } from './tailwind-common';
 
 import {
+  type TailwindCSSThemeOptions,
+
   makeCSSTheme,
   makeColorConfig,
 } from './tailwind-theme';
 
 import type { Config, PluginCreator } from 'tailwindcss/types/config';
 
-type MaterialColorOptions = Partial<MakeCSSThemeOptions>;
-
-function defaultMaterialColorOptions(options: MaterialColorOptions = {}): MakeCSSThemeOptions {
+function defaultMaterialColorOptions(options: TailwindCSSThemeOptions = {}): MakeCSSThemeOptions {
   return {
     prefix: 'md-',
     darkSuffix: '-dark',
@@ -52,11 +52,12 @@ function darkStyleNotPrintPlugin(darkMode: string = '.dark') {
 /** withColorConfig adds the colors to the TailwindCSS Config */
 function withColorConfig<K extends string>(config: Partial<Config>,
   colors: ThemeColors<K> | ThemeColorOptions<K>,
-  prefix?: string): Partial<Config> {
+  options: TailwindCSSThemeOptions = {},
+): Partial<Config> {
   //
   const theme: PropType<Config, 'theme'> = {
     extend: {
-      colors: makeColorConfig(colors, prefix),
+      colors: makeColorConfig(colors, options),
     },
   };
 
@@ -79,7 +80,7 @@ function withColorConfig<K extends string>(config: Partial<Config>,
 
 function withCSSTheme<K extends string>(config: Partial<Config>,
   colors: ThemeColors<K>,
-  options: MakeCSSThemeOptions = {} as MakeCSSThemeOptions,
+  options: TailwindCSSThemeOptions = {},
 ): Partial<Config> {
   const theme = makeCSSTheme(colors, options);
   const styles: CSSRuleObject[] = [];
@@ -136,11 +137,11 @@ function withCSSTheme<K extends string>(config: Partial<Config>,
 
 export function withMaterialColors<K extends string>(config: Partial<Config>,
   colors: ThemeColors<K>,
-  options: MaterialColorOptions = {},
+  options: TailwindCSSThemeOptions = {},
 ): Partial<Config> {
   const $options = defaultMaterialColorOptions(options);
   config = withCSSTheme(config, colors, $options);
-  config = withColorConfig(config, colors, $options.prefix);
+  config = withColorConfig(config, colors, $options);
   return config;
 }
 

--- a/packages/theme-builder/src/tailwind-shades.ts
+++ b/packages/theme-builder/src/tailwind-shades.ts
@@ -11,8 +11,7 @@ import {
   hexFromHct,
 } from './core';
 
-// export
-//
+/** list of shades to use by default */
 export const defaultShades = [
   50,
   100,
@@ -24,6 +23,7 @@ export const defaultShades = [
   700,
   800,
   900,
+  950,
 ];
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
	- Bumped package version from `0.4.0` to `0.4.1`

- **New Features**
	- Added new color shade `950` to default shades
	- Introduced more flexible color configuration options for Tailwind themes

- **Improvements**
	- Enhanced color handling with new type declarations and option management
	- Expanded color shade granularity for theme configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->