### PR TITLE
feat(theme-builder): tailwind: introduce option the replace colors rather than extend them

### DIFF
--- a/packages/theme-builder/src/tailwind-config.ts
+++ b/packages/theme-builder/src/tailwind-config.ts
@@ -1,3 +1,4 @@
+import defaultColors from 'tailwindcss/colors.js';
 import plugin from 'tailwindcss/plugin.js';
 
 import {
@@ -37,19 +38,32 @@ function withColorConfig<K extends string>(config: Partial<Config>,
   options: TailwindThemeOptions = {},
 ): Partial<Config> {
   //
+  const { extend = true } = options;
   const tailwindColors = makeColorConfig(colors, options);
   const theme: PropType<Config, 'theme'> = {
     ...config?.theme,
   };
 
-  // extend colors
-  theme.extend = {
-    ...theme.extend,
-    colors: {
-      ...theme.extend?.colors,
+  if (extend) {
+    // extend colors
+    theme.extend = {
+      ...theme.extend,
+      colors: {
+        ...theme.extend?.colors,
+        ...tailwindColors,
+      },
+    };
+  } else {
+    // replace colors
+    theme.colors = {
+      inherit: defaultColors.inherit,
+      current: defaultColors.current,
+      transparent: defaultColors.transparent,
+      black: defaultColors.black,
+      white: defaultColors.white,
       ...tailwindColors,
-    },
-  };
+    };
+  }
 
   return {
     ...config,

--- a/packages/theme-builder/src/tailwind-config.ts
+++ b/packages/theme-builder/src/tailwind-config.ts
@@ -11,31 +11,13 @@ import {
 } from './dynamic-theme';
 
 import {
-  MakeCSSThemeOptions,
-} from './dynamic-color-css';
-
-import {
-  rgbFromHct,
-} from './tailwind-common';
-
-import {
-  type TailwindCSSThemeOptions,
+  type TailwindThemeOptions,
 
   makeCSSTheme,
   makeColorConfig,
 } from './tailwind-theme';
 
 import type { Config, PluginCreator } from 'tailwindcss/types/config';
-
-function defaultMaterialColorOptions(options: TailwindCSSThemeOptions = {}): MakeCSSThemeOptions {
-  return {
-    prefix: 'md-',
-    darkSuffix: '-dark',
-    lightSuffix: '-light',
-    stringify: rgbFromHct,
-    ...options,
-  };
-}
 
 // helpers
 //
@@ -52,35 +34,32 @@ function darkStyleNotPrintPlugin(darkMode: string = '.dark') {
 /** withColorConfig adds the colors to the TailwindCSS Config */
 function withColorConfig<K extends string>(config: Partial<Config>,
   colors: ThemeColors<K> | ThemeColorOptions<K>,
-  options: TailwindCSSThemeOptions = {},
+  options: TailwindThemeOptions = {},
 ): Partial<Config> {
   //
+  const tailwindColors = makeColorConfig(colors, options);
   const theme: PropType<Config, 'theme'> = {
-    extend: {
-      colors: makeColorConfig(colors, options),
+    ...config?.theme,
+  };
+
+  // extend colors
+  theme.extend = {
+    ...theme.extend,
+    colors: {
+      ...theme.extend?.colors,
+      ...tailwindColors,
     },
   };
 
   return {
     ...config,
-    theme: {
-      ...config?.theme,
-      ...theme,
-      extend: {
-        ...config?.theme?.extend,
-        ...theme?.extend,
-        colors: {
-          ...config?.theme?.extend?.colors,
-          ...theme?.extend?.colors,
-        },
-      },
-    },
+    theme,
   };
 }
 
 function withCSSTheme<K extends string>(config: Partial<Config>,
   colors: ThemeColors<K>,
-  options: TailwindCSSThemeOptions = {},
+  options: TailwindThemeOptions = {},
 ): Partial<Config> {
   const theme = makeCSSTheme(colors, options);
   const styles: CSSRuleObject[] = [];
@@ -137,11 +116,10 @@ function withCSSTheme<K extends string>(config: Partial<Config>,
 
 export function withMaterialColors<K extends string>(config: Partial<Config>,
   colors: ThemeColors<K>,
-  options: TailwindCSSThemeOptions = {},
+  options: TailwindThemeOptions = {},
 ): Partial<Config> {
-  const $options = defaultMaterialColorOptions(options);
-  config = withCSSTheme(config, colors, $options);
-  config = withColorConfig(config, colors, $options);
+  config = withCSSTheme(config, colors, options);
+  config = withColorConfig(config, colors, options);
   return config;
 }
 

--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -64,6 +64,9 @@ function getColorShadesOption<K extends string>(color: K, fallback: Shades = tru
 export interface TailwindThemeOptions extends Partial<MakeCSSThemeOptions> {
   /** @defaultValue `true` */
   shades?: Shades
+
+  /** @defaultValue `true` */
+  extend?: boolean
 }
 
 /**

--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -61,7 +61,7 @@ function getColorShadesOption<K extends string>(color: K, fallback: Shades = tru
 }
 
 /** options for {@link makeCSSTheme} */
-export interface TailwindCSSThemeOptions extends Partial<MakeCSSThemeOptions> {
+export interface TailwindThemeOptions extends Partial<MakeCSSThemeOptions> {
   /** @defaultValue `true` */
   shades?: Shades
 }
@@ -74,7 +74,7 @@ export interface TailwindCSSThemeOptions extends Partial<MakeCSSThemeOptions> {
  * @returns  CSSRuleObjects to set up dark/light themes.
  */
 export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
-  options: TailwindCSSThemeOptions = {},
+  options: TailwindThemeOptions = {},
 ) {
   const { dark, light, darkPalette, lightPalette, colorOptions } = makeTheme(colors, options.scheme, options.contrastLevel);
 
@@ -112,21 +112,13 @@ export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
   });
 }
 
-interface MakeColorConfigOptions {
-  /** @defaultValue `'md-` */
-  prefix?: string
-
-  /** @defaultValue `true` */
-  shades?: Shades
-};
-
 /**
  * @param colors - describes the colors of the theme.
  * @param prefix - indicates the prefix used for the CSS variables.
  * @returns tailwindcss Config theme colors using the CSS variables associated with the theme.
  */
 export function makeColorConfig<K extends string>(colors: ThemeColorOptions<K> | ThemeColors<K>,
-  options: MakeColorConfigOptions = {},
+  options: TailwindThemeOptions = {},
 ) {
   const { prefix = 'md-' } = options;
   const { keys, paletteKeys, colorOptions } = makeThemeKeys(colors);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `TailwindCSSThemeOptions` to `TailwindThemeOptions`
	- Simplified theme configuration handling
	- Removed `defaultMaterialColorOptions` function
	- Added optional `extend` property for theme color configurations

- **Improvements**
	- Streamlined theme and color option management
	- Enhanced flexibility in theme customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->