### PR TITLE
feat(theme-builder): tailwind: safelist darkMode and lightMode classes

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/dynamic-color-css.ts
+++ b/packages/theme-builder/src/dynamic-color-css.ts
@@ -44,7 +44,8 @@ export function defaultCSSThemeOptions(options: Partial<CSSThemeOptions> = {}): 
   };
 }
 
-function defaultDarkSelector(options: Partial<CSSThemeOptions>) {
+/** @returns the dark mode selector or media rule */
+export function defaultDarkSelector(options: Partial<CSSThemeOptions>) {
   const { darkMode = true } = options;
   if (darkMode === true || darkMode === '.dark')
     return '.dark';
@@ -54,7 +55,8 @@ function defaultDarkSelector(options: Partial<CSSThemeOptions>) {
     return darkMode;
 }
 
-function defaultLightSelector(options: Partial<CSSThemeOptions>) {
+/** @returns the light mode selector, or undefined if disabled */
+export function defaultLightSelector(options: Partial<CSSThemeOptions>) {
   const { lightMode = true } = options;
   if (lightMode === true || lightMode === '.light')
     return '.light';

--- a/packages/theme-builder/src/tailwind-config.ts
+++ b/packages/theme-builder/src/tailwind-config.ts
@@ -6,6 +6,11 @@ import {
 } from './utils';
 
 import {
+  defaultDarkSelector,
+  defaultLightSelector,
+} from './dynamic-color-css';
+
+import {
   type ThemeColors,
   type ThemeColorOptions,
 } from './dynamic-theme';
@@ -70,6 +75,19 @@ function withColorConfig<K extends string>(config: Partial<Config>,
   };
 }
 
+function generateSafeList(options: TailwindThemeOptions) {
+  const safelist: PropType<Config, 'safelist'> = [];
+  const darkSelector = defaultDarkSelector(options);
+  const lightSelector = defaultLightSelector(options);
+
+  if (darkSelector.charAt(0) === '.')
+    safelist.push(darkSelector.slice(1));
+  if (lightSelector?.charAt(0) === '.')
+    safelist.push(lightSelector.slice(1));
+
+  return safelist;
+}
+
 function withCSSTheme<K extends string>(config: Partial<Config>,
   colors: ThemeColors<K>,
   options: TailwindThemeOptions = {},
@@ -81,9 +99,15 @@ function withCSSTheme<K extends string>(config: Partial<Config>,
     plugin(({ addBase }) => addBase(styles)),
   ];
 
+  const safelist: PropType<Config, 'safelist'> = [
+    ...(config?.safelist || []),
+    ...generateSafeList(options),
+  ];
+
   config = {
     ...config,
     plugins,
+    safelist,
   };
 
   return config;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Version Update**
	- Updated `@poupe/theme-builder` package version from `0.4.3` to `0.4.4`

- **New Features**
	- Exposed dark and light mode selector functions
	- Added a new function to generate dynamic safelists for Tailwind CSS configuration

- **Documentation**
	- Added JSDoc comments to selector functions for improved clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->