### PR TITLE
feat(theme-builder): tailwind: withShades(), Config and PropType

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/tailwind-shades.ts
+++ b/packages/theme-builder/src/tailwind-shades.ts
@@ -3,7 +3,6 @@
 import { Prettify } from './utils';
 
 import {
-  type HexColor,
   type Color,
   Hct,
 
@@ -71,11 +70,22 @@ export function makeShades(color: Color, shades: Shades = true) {
   return out as Prettify<typeof out>;
 }
 
-export function makeHexShades(baseColor: Color, shades: Shades = true) {
-  const t = makeShades(baseColor, shades);
+function hexStringify<V extends string>(c: Hct): V {
+  /* work around HexColor return value */
+  return hexFromHct(c) as V;
+}
+
+/** @returns a map of shades of the baseColor to be used in tailwind.config.
+ *
+ * @param baseColor - color used as reference for hue and chroma.
+ * @param shades - optional array of shades to use, {@link defaultShades} by default.
+ * @param stringify - optional {@link Hct} to `string` convertor.
+ */
+export function withShades<V extends string>(baseColor: string | Hct, shades: Shades = true, stringify: ((c: Hct) => V) = hexStringify) {
+  const t = makeShades(hct(baseColor), shades);
 
   type K = keyof typeof t;
-  type T = Record<K, HexColor>;
+  type T = Record<K, V>;
 
   const keys = Object.keys(t) as K[];
   const out = {} as Partial<T>;
@@ -83,7 +93,7 @@ export function makeHexShades(baseColor: Color, shades: Shades = true) {
   for (const shade of keys) {
     const c = t[shade];
     if (c !== undefined) {
-      out[shade] = hexFromHct(c);
+      out[shade] = stringify(c);
     }
   }
 

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -27,7 +27,7 @@ export {
   type Shades,
 
   makeShades,
-  makeHexShades,
+  withShades,
 } from './tailwind-shades';
 
 export {

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -1,4 +1,5 @@
 export {
+  type PropType,
   type CSSRuleObject,
 
   formatCSSRuleObjects,
@@ -38,3 +39,7 @@ export {
   withMaterialColors,
   withPrintMode,
 } from './tailwind-config';
+
+export {
+  type Config,
+} from 'tailwindcss/types/config';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `hexStringify` function for flexible color representation.
  - Added new type exports for enhanced functionality.

- **Refactor**
  - Removed the `makeHexShades` function and replaced it with `withShades`.
  - Updated type definitions to accept both string and `Hct` objects.

- **Chores**
  - Updated the package version from `0.4.4` to `0.4.5`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->