### PR TITLE
feat(theme-builder): index: introduce fromImageElement()

### DIFF
--- a/packages/theme-builder/src/from-image.ts
+++ b/packages/theme-builder/src/from-image.ts
@@ -1,0 +1,12 @@
+import {
+  Hct,
+
+  sourceColorFromImage,
+} from '@material/material-color-utilities';
+
+/** @returns a color suitable to make a theme from the given image element. */
+export async function fromImageElement(image: HTMLImageElement): Promise<Hct> {
+  const color = await sourceColorFromImage(image);
+
+  return Hct.fromInt(color);
+}

--- a/packages/theme-builder/src/index.ts
+++ b/packages/theme-builder/src/index.ts
@@ -3,3 +3,4 @@ export * from './dynamic-color';
 export * from './dynamic-color-data';
 export * from './dynamic-color-css';
 export * from './dynamic-theme';
+export * from './from-image';


### PR DESCRIPTION
wrapping material-color-utils' sourceColorFromImage()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added ability to extract theme colors directly from an image element
	- Expanded theme builder module's public API to support image-based color generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->