### PR TITLE
feat(theme-builder): tailwind: introduce omitTheme option for withMaterialColors()

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/dynamic-theme.ts
+++ b/packages/theme-builder/src/dynamic-theme.ts
@@ -43,8 +43,15 @@ function flattenPartialColorOptions(c?: Color | ColorOptions | Partial<ColorOpti
 }
 
 /** flattens ThemeColors */
-function flattenColorOptions(c: Color | ColorOptions): ColorOptions {
-  return c instanceof Hct || typeof c !== 'object' ? { value: c } : c;
+function flattenColorOptions(c: Color | ColorOptions | Partial<ColorOptions>): ColorOptions {
+  const p: Partial<ColorOptions> = c instanceof Hct || typeof c !== 'object' ? { value: c } : c;
+  if (p.value === undefined)
+    throw new TypeError('color value not specified');
+
+  return {
+    ...p,
+    value: hct(p.value),
+  };
 }
 
 /**
@@ -75,7 +82,7 @@ export function flattenPartialThemeColors<K extends string>(colors: ThemeColorOp
 }
 
 /** flattens a ThemeColors */
-export function flattenThemeColors<K extends string>(colors: ThemeColors<K>) {
+export function flattenThemeColors<K extends string>(colors: ThemeColorOptions<K> | ThemeColors<K>) {
   const out = {} as Record<keyof typeof colors, ColorOptions>;
   const keys = Object.keys(colors) as Array<keyof typeof colors>;
 

--- a/packages/theme-builder/src/tailwind-config.ts
+++ b/packages/theme-builder/src/tailwind-config.ts
@@ -13,6 +13,7 @@ import {
 import {
   type ThemeColors,
   type ThemeColorOptions,
+  flattenThemeColors,
 } from './dynamic-theme';
 
 import {
@@ -113,11 +114,21 @@ function withCSSTheme<K extends string>(config: Partial<Config>,
   return config;
 }
 
+interface MaterialColorOptions extends TailwindThemeOptions {
+  /** @defaultValue `false` */
+  omitTheme?: boolean
+}
+
 export function withMaterialColors<K extends string>(config: Partial<Config>,
-  colors: ThemeColors<K>,
-  options: TailwindThemeOptions = {},
+  colors: ThemeColors<K> | ThemeColorOptions<K>,
+  options: MaterialColorOptions = {},
 ): Partial<Config> {
-  config = withCSSTheme(config, colors, options);
+  const { omitTheme = false } = options;
+  if (!omitTheme) {
+    const $colors = flattenThemeColors<K>(colors);
+    config = withCSSTheme(config, $colors, options);
+  }
+
   config = withColorConfig(config, colors, options);
   return config;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced theme builder functionality with more flexible color options
	- Added optional theme omission capability in color configuration

- **Improvements**
	- Improved error handling for color value specifications
	- Expanded input type support for theme color functions
	- Increased robustness of color processing methods

- **Bug Fixes**
	- Resolved potential type-related constraints in theme color handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->