### PR TITLE
feat(theme-builder): use HCT capitalised instead of Hct [BREAKING]

### DIFF
--- a/packages/theme-builder/src/core.ts
+++ b/packages/theme-builder/src/core.ts
@@ -3,7 +3,7 @@
 import {
   type CustomColor,
   DynamicScheme,
-  Hct,
+  Hct as HCT,
 
   customColor as customColorFromArgb,
 
@@ -27,7 +27,7 @@ export {
 export {
   type CustomColor,
   DynamicScheme,
-  Hct,
+  Hct as HCT,
 
   customColor as customColorFromArgb,
 
@@ -44,12 +44,12 @@ export type standardDynamicSchemeFactory = (primary: Color, isDark: boolean, con
 // types
 //
 export type HexColor = `#${string}`;
-export type Color = Hct | HexColor | number;
-export type ColorMap<K extends string> = Record<K, Hct>;
+export type Color = HCT | HexColor | number;
+export type ColorMap<K extends string> = Record<K, HCT>;
 
 // tools
 //
-export const customColorFromHct = (source: Hct, color: CustomColor) => customColorFromArgb(source.toInt(), color);
+export const customColorFromHCT = (source: HCT, color: CustomColor) => customColorFromArgb(source.toInt(), color);
 
 export const hexColorPattern = /^#([\da-f]{3}|[\da-f]{6}|[\da-f]{8})$/i;
 export const isHexColor = (s: string = '') => !!hexColorPattern.test(s || '');
@@ -63,18 +63,18 @@ export function hexFromString(value: string): HexColor {
     throw new TypeError('not HexColor string');
 }
 
-export const argbFromHct = (c: Hct) => {
-  if (c instanceof Hct) {
+export const argbFromHCT = (c: HCT) => {
+  if (c instanceof HCT) {
     return c.toInt();
   }
-  throw new TypeError('not Hct object');
+  throw new TypeError('not HCT object');
 };
 
 export const argbFromHex = (hex: string) => mcuArgbFromHex(hexFromString(hex));
 export const hexFromArgb = (argb: number) => mcuHexFromArgb(argb) as HexColor;
-export const hexFromHct = (c: Hct) => hexFromArgb(argbFromHct(c));
-export const hctFromHex = (hex: string) => Hct.fromInt(argbFromHex(hex));
-export const hctFromArgb = (argb: number) => Hct.fromInt(argb);
+export const hexFromHCT = (c: HCT) => hexFromArgb(argbFromHCT(c));
+export const hctFromHex = (hex: string) => HCT.fromInt(argbFromHex(hex));
+export const hctFromArgb = (argb: number) => HCT.fromInt(argb);
 
 export type ARGB = {
   a?: number
@@ -97,7 +97,7 @@ export const rgbFromArgb = (argb: number) => {
   return `rgb(${r} ${g} ${b})`;
 };
 
-export const rgbFromHct = (c: Hct) => rgbFromArgb(argbFromHct(c));
+export const rgbFromHCT = (c: HCT) => rgbFromArgb(argbFromHCT(c));
 
 export type HSL = {
   a?: number
@@ -141,14 +141,14 @@ export const hslFromArgb = (argb: number): HSL => {
   };
 };
 
-export const hslFromHct = (c: Hct): HSL => hslFromArgb(argbFromHct(c));
+export const hslFromHCT = (c: HCT): HSL => hslFromArgb(argbFromHCT(c));
 
 /**
- * @param value - color to convert to Hct.
- * @returns Hct representation of the given color.
+ * @param value - color to convert to HCT.
+ * @returns HCT representation of the given color.
  */
-export const hct = (value: string | Hct | number): Hct => {
-  if (value instanceof Hct) {
+export const hct = (value: string | HCT | number): HCT => {
+  if (value instanceof HCT) {
     return value;
   } else if (typeof value === 'number') {
     return hctFromArgb(value);
@@ -161,9 +161,9 @@ export const hct = (value: string | Hct | number): Hct => {
  * @param value - color to convert to ARGB
  * @returns ARGB representation of the given color.
  */
-export const argb = (value: string | Hct | number): number => {
-  if (value instanceof Hct) {
-    return argbFromHct(value);
+export const argb = (value: string | HCT | number): number => {
+  if (value instanceof HCT) {
+    return argbFromHCT(value);
   } else if (typeof value === 'number') {
     return value;
   } else {
@@ -175,9 +175,9 @@ export const argb = (value: string | Hct | number): number => {
  * @param value - color to convert to HexColor
  * @returns HexColor representation of the given Color.
  */
-export const hex = (value: string | Hct | number): HexColor => {
-  if (value instanceof Hct) {
-    return hexFromHct(value);
+export const hex = (value: string | HCT | number): HexColor => {
+  if (value instanceof HCT) {
+    return hexFromHCT(value);
   } else if (typeof value === 'number') {
     return hexFromArgb(value);
   } else {

--- a/packages/theme-builder/src/dynamic-color-css.ts
+++ b/packages/theme-builder/src/dynamic-color-css.ts
@@ -1,9 +1,9 @@
 import {
   type ColorMap,
   type CSSRuleObject,
-  type Hct,
+  type HCT,
 
-  rgbFromHct,
+  rgbFromHCT,
 } from './core';
 
 import {
@@ -28,7 +28,7 @@ export interface CSSThemeOptions {
   /** @defaultValue `'-light'` */
   lightSuffix: string
   /** @defaultValue `rgb('{r} {g} {b}')` */
-  stringify: (c: Hct) => string
+  stringify: (c: HCT) => string
 };
 
 /** apply defaults to {@link CSSThemeOptions} */
@@ -39,7 +39,7 @@ export function defaultCSSThemeOptions(options: Partial<CSSThemeOptions> = {}): 
     prefix: 'md-',
     darkSuffix: '-dark',
     lightSuffix: '-light',
-    stringify: rgbFromHct,
+    stringify: rgbFromHCT,
     ...options,
   };
 }

--- a/packages/theme-builder/src/dynamic-color.ts
+++ b/packages/theme-builder/src/dynamic-color.ts
@@ -3,7 +3,7 @@
 import {
   type Color,
   DynamicScheme,
-  Hct,
+  HCT,
 
   argb,
   customColorFromArgb,
@@ -59,10 +59,10 @@ export function getColorNameOption<K extends string>(color: K, colors: Record<K,
   }
 }
 
-type StandardDynamicColors = { [K in StandardDynamicColorKey]: Hct };
-type StandardPaletteColors = { [K in StandardPaletteKey]: Hct };
+type StandardDynamicColors = { [K in StandardDynamicColorKey]: HCT };
+type StandardPaletteColors = { [K in StandardPaletteKey]: HCT };
 
-type CustomDynamicColors<T extends string> = { [K in CustomDynamicColorKey<KebabCase<T>>]: Hct };
+type CustomDynamicColors<T extends string> = { [K in CustomDynamicColorKey<KebabCase<T>>]: HCT };
 
 export function makeStandardColorsFromScheme(scheme: DynamicScheme) {
   const out: Partial<StandardDynamicColors> = {};
@@ -84,7 +84,7 @@ export function makeStandardPaletteFromScheme(scheme: DynamicScheme) {
   return out as StandardPaletteColors;
 }
 
-function customColor(source: Hct, name: string, option: ColorOptions) {
+function customColor(source: HCT, name: string, option: ColorOptions) {
   const value = argb(option.value);
   const blend = option.harmonize === undefined ? true : option.harmonize;
 
@@ -113,8 +113,8 @@ export function makeCustomColors<K extends string>(source: Color, colors: Record
     for (const [pattern, fn] of Object.entries(customDynamicColors)) {
       const name = pattern.replace('{}', kebabName) as keyof customDynamicColors;
 
-      darkColors[name] = Hct.fromInt(fn(dark));
-      lightColors[name] = Hct.fromInt(fn(light));
+      darkColors[name] = HCT.fromInt(fn(dark));
+      lightColors[name] = HCT.fromInt(fn(light));
     }
   }
 

--- a/packages/theme-builder/src/dynamic-theme.ts
+++ b/packages/theme-builder/src/dynamic-theme.ts
@@ -6,7 +6,7 @@ import {
 
 import {
   type Color,
-  Hct,
+  HCT,
 
   hct,
 } from './core';
@@ -35,7 +35,7 @@ import {
 function flattenPartialColorOptions(c?: Color | ColorOptions | Partial<ColorOptions>): Partial<ColorOptions> {
   if (c === undefined) {
     return {};
-  } else if (c instanceof Hct || typeof c !== 'object') {
+  } else if (c instanceof HCT || typeof c !== 'object') {
     return { value: c };
   } else {
     return c;
@@ -44,7 +44,7 @@ function flattenPartialColorOptions(c?: Color | ColorOptions | Partial<ColorOpti
 
 /** flattens ThemeColors */
 function flattenColorOptions(c: Color | ColorOptions | Partial<ColorOptions>): ColorOptions {
-  const p: Partial<ColorOptions> = c instanceof Hct || typeof c !== 'object' ? { value: c } : c;
+  const p: Partial<ColorOptions> = c instanceof HCT || typeof c !== 'object' ? { value: c } : c;
   if (p.value === undefined)
     throw new TypeError('color value not specified');
 
@@ -169,23 +169,23 @@ export function makeTheme<K extends string>(colors: ThemeColors<K>,
     ...customColorOptions,
   };
 
-  const dark: { [P in ColorKey]: Hct } = {
+  const dark: { [P in ColorKey]: HCT } = {
     ...darkPalette,
     ...darkStandardColors,
     ...darkCustomColors,
   };
 
-  const light: { [P in ColorKey]: Hct } = {
+  const light: { [P in ColorKey]: HCT } = {
     ...lightPalette,
     ...lightStandardColors,
     ...lightCustomColors,
   };
 
-  const darkCustomPalette: Record<string, Hct> = {
+  const darkCustomPalette: Record<string, HCT> = {
     ...darkPalette,
   };
 
-  const lightCustomPalette: Record<string, Hct> = {
+  const lightCustomPalette: Record<string, HCT> = {
     ...lightPalette,
   };
 
@@ -199,8 +199,8 @@ export function makeTheme<K extends string>(colors: ThemeColors<K>,
     colorOptions,
     darkScheme,
     lightScheme,
-    darkPalette: darkCustomPalette as { [P in PaletteKey]: Hct },
-    lightPalette: lightCustomPalette as { [P in PaletteKey]: Hct },
+    darkPalette: darkCustomPalette as { [P in PaletteKey]: HCT },
+    lightPalette: lightCustomPalette as { [P in PaletteKey]: HCT },
     dark,
     light,
   };

--- a/packages/theme-builder/src/from-image.ts
+++ b/packages/theme-builder/src/from-image.ts
@@ -1,12 +1,12 @@
 import {
-  Hct,
+  Hct as HCT,
 
   sourceColorFromImage,
 } from '@material/material-color-utilities';
 
 /** @returns a color suitable to make a theme from the given image element. */
-export async function fromImageElement(image: HTMLImageElement): Promise<Hct> {
+export async function fromImageElement(image: HTMLImageElement): Promise<HCT> {
   const color = await sourceColorFromImage(image);
 
-  return Hct.fromInt(color);
+  return HCT.fromInt(color);
 }

--- a/packages/theme-builder/src/tailwind-common.ts
+++ b/packages/theme-builder/src/tailwind-common.ts
@@ -1,9 +1,9 @@
 // imports
 //
 import {
-  Hct,
+  HCT,
 
-  argbFromHct,
+  argbFromHCT,
   splitArgb,
 } from './core';
 
@@ -13,5 +13,5 @@ export const rgbFromArgb = (argb: number) => {
   return `${r} ${g} ${b}`;
 };
 
-// rgbFromHct for tailwindcss color variables.
-export const rgbFromHct = (c: Hct) => rgbFromArgb(argbFromHct(c));
+// rgbFromHCT for tailwindcss color variables.
+export const rgbFromHCT = (c: HCT) => rgbFromArgb(argbFromHCT(c));

--- a/packages/theme-builder/src/tailwind-shades.ts
+++ b/packages/theme-builder/src/tailwind-shades.ts
@@ -4,10 +4,10 @@ import { Prettify } from './utils';
 
 import {
   type Color,
-  Hct,
+  HCT,
 
   hct,
-  hexFromHct,
+  hexFromHCT,
 } from './core';
 
 /** list of shades to use by default */
@@ -46,7 +46,7 @@ export type Shade = number | 'DEFAULT';
 export function makeShades(color: Color, shades: Shades = true) {
   const c1 = hct(color);
 
-  const out: Record<Shade, Hct> = {
+  const out: Record<Shade, HCT> = {
     DEFAULT: c1,
   };
 
@@ -63,25 +63,25 @@ export function makeShades(color: Color, shades: Shades = true) {
     if (typeof shade === 'number' && shade >= 0 && shade <= 1000) {
       const tone = (1000 - shade) / 10;
 
-      out[shade] = Hct.from(hue, chroma, tone);
+      out[shade] = HCT.from(hue, chroma, tone);
     }
   }
 
   return out as Prettify<typeof out>;
 }
 
-function hexStringify<V extends string>(c: Hct): V {
+function hexStringify<V extends string>(c: HCT): V {
   /* work around HexColor return value */
-  return hexFromHct(c) as V;
+  return hexFromHCT(c) as V;
 }
 
 /** @returns a map of shades of the baseColor to be used in tailwind.config.
  *
  * @param baseColor - color used as reference for hue and chroma.
  * @param shades - optional array of shades to use, {@link defaultShades} by default.
- * @param stringify - optional {@link Hct} to `string` convertor.
+ * @param stringify - optional {@link HCT} to `string` convertor.
  */
-export function withShades<V extends string>(baseColor: string | Hct, shades: Shades = true, stringify: ((c: Hct) => V) = hexStringify) {
+export function withShades<V extends string>(baseColor: string | HCT, shades: Shades = true, stringify: ((c: HCT) => V) = hexStringify) {
   const t = makeShades(hct(baseColor), shades);
 
   type K = keyof typeof t;

--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -3,7 +3,7 @@ import {
 } from './utils';
 
 import {
-  Hct,
+  HCT,
 } from './core';
 
 import {
@@ -27,7 +27,7 @@ import {
 } from './dynamic-theme';
 
 import {
-  rgbFromHct,
+  rgbFromHCT,
 } from './tailwind-common';
 
 import {
@@ -82,11 +82,11 @@ export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
   const { dark, light, darkPalette, lightPalette, colorOptions } = makeTheme(colors, options.scheme, options.contrastLevel);
 
   // shades
-  const darkColors: Record<string, Hct> = {
+  const darkColors: Record<string, HCT> = {
     ...dark,
   };
 
-  const lightColors: Record<string, Hct> = {
+  const lightColors: Record<string, HCT> = {
     ...light,
   };
 
@@ -110,7 +110,7 @@ export function makeCSSTheme<K extends string>(colors: ThemeColors<K>,
   }
 
   return assembleCSSColors(darkColors, lightColors, {
-    stringify: rgbFromHct,
+    stringify: rgbFromHCT,
     ...options,
   });
 }

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -8,10 +8,10 @@ export {
 export {
   type Color,
   type HexColor,
-  Hct,
+  HCT,
 
   hct,
-  hexFromHct,
+  hexFromHCT,
 } from './core';
 
 export {
@@ -19,7 +19,7 @@ export {
 } from './dynamic-color-data';
 
 export {
-  rgbFromHct,
+  rgbFromHCT,
 } from './tailwind-common';
 
 export {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed `Hct` type to `HCT` across multiple files in the theme builder package
	- Updated function signatures and type declarations to use consistent `HCT` capitalization
	- Standardized color-related function and type naming conventions

- **Documentation**
	- Improved type consistency for color handling methods and interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->