### PR TITLE
feat(theme-builder): tailwind: create initial surface components

### DIFF
--- a/packages/theme-builder/src/tailwind-config.ts
+++ b/packages/theme-builder/src/tailwind-config.ts
@@ -26,6 +26,12 @@ import {
   makeColorConfig,
 } from './tailwind-theme';
 
+import {
+  type SurfaceComponentsOptions,
+
+  withSurfaceComponents,
+} from './tailwind/index';
+
 export * from './tailwind/index';
 
 // helpers
@@ -110,18 +116,31 @@ function withCSSTheme<K extends string>(config: Partial<Config>,
 interface MaterialColorOptions extends TailwindThemeOptions {
   /** @defaultValue `false` */
   omitTheme?: boolean
+
+  /** @defaultValue `true` */
+  surfaceComponents?: boolean | Partial<SurfaceComponentsOptions>
 }
 
 export function withMaterialColors<K extends string>(config: Partial<Config>,
   colors: ThemeColors<K> | ThemeColorOptions<K>,
   options: MaterialColorOptions = {},
 ): Partial<Config> {
-  const { omitTheme = false } = options;
+  const {
+    omitTheme = false,
+    surfaceComponents = true,
+  } = options;
+
   if (!omitTheme) {
     const $colors = flattenThemeColors<K>(colors);
     config = withCSSTheme(config, $colors, options);
   }
 
   config = withColorConfig(config, colors, options);
+
+  if (surfaceComponents !== false) {
+    const $options = typeof surfaceComponents === 'object' ? surfaceComponents : {};
+    config = withSurfaceComponents(config, $options);
+  }
+
   return config;
 }

--- a/packages/theme-builder/src/tailwind/common.ts
+++ b/packages/theme-builder/src/tailwind/common.ts
@@ -20,6 +20,7 @@ export type SafelistConfig = PropType<Config, 'safelist'>;
 export type ThemeConfig = PropType<Config, 'theme'>;
 
 export type PluginThemeAPI = PropType<PluginAPI, 'theme'>;
+export type PluginConfigAPI = PropType<PluginAPI, 'config'>;
 
 /*
  * Data

--- a/packages/theme-builder/src/tailwind/common.ts
+++ b/packages/theme-builder/src/tailwind/common.ts
@@ -4,19 +4,22 @@ import {
 
 import {
   type Config,
+  type PluginAPI,
 } from 'tailwindcss/types/config';
 
 /*
  * Types
  */
-export type {
-  Config,
-  PluginCreator,
+export {
+  type Config,
+  type PluginCreator,
 } from 'tailwindcss/types/config';
 
 export type PluginsConfig = PropType<Config, 'plugins'>;
 export type SafelistConfig = PropType<Config, 'safelist'>;
 export type ThemeConfig = PropType<Config, 'theme'>;
+
+export type PluginThemeAPI = PropType<PluginAPI, 'theme'>;
 
 /*
  * Data

--- a/packages/theme-builder/src/tailwind/index.ts
+++ b/packages/theme-builder/src/tailwind/index.ts
@@ -4,7 +4,5 @@ export {
   defaultColors,
 } from './common';
 
-export {
-  darkStyleNotPrintPlugin,
-  withPrintMode,
-} from './plugin-print-mode';
+export * from './plugin-print-mode';
+export * from './plugin-surfaces';

--- a/packages/theme-builder/src/tailwind/plugin-surfaces.ts
+++ b/packages/theme-builder/src/tailwind/plugin-surfaces.ts
@@ -95,11 +95,19 @@ function assembleSurfaceComponent(options: SurfaceComponentsOptions, colorName: 
   }
 
   // combine bg- and text-on-
+  const surfaceName = makeSurfaceName(colorName, surfacePrefix);
   return {
-    [`.${surfacePrefix}${colorName}`]: {
+    [`.${surfaceName}`]: {
       [`@apply ${bgPrefix}${colorName} ${textPrefix}${onColorName}`]: {},
     },
   };
+}
+
+function makeSurfaceName(colorName: string, prefix: string): string {
+  if (colorName.startsWith(prefix) || `${colorName}-` === prefix) {
+    return colorName;
+  }
+  return `${prefix}${colorName}`;
 }
 
 function defaultSurfaceComponentsOptions(options: Partial<SurfaceComponentsOptions>): SurfaceComponentsOptions {

--- a/packages/theme-builder/src/tailwind/plugin-surfaces.ts
+++ b/packages/theme-builder/src/tailwind/plugin-surfaces.ts
@@ -1,0 +1,111 @@
+import {
+  type Config,
+  type PluginsConfig,
+  type PluginCreator,
+  type PluginThemeAPI,
+
+  defaultColors,
+  plugin,
+} from './common';
+
+import {
+  type CSSRuleObject,
+} from 'tailwindcss/types/config';
+
+/** options for {@link surfaceComponentsPlugin} */
+export type SurfaceComponentsOptions = {
+  /** @defaultValue `'surface-'` */
+  surfacePrefix: string
+
+  /** @defaultValue `'bg-'` */
+  bgPrefix: string
+
+  /** @defaultValue `'text-'` */
+  textPrefix: string
+};
+
+/** @returns {@link Config} extended to include plugin to generate surface components. */
+export function withSurfaceComponents(config: Partial<Config> = {}, options: Partial<SurfaceComponentsOptions> = {}): Partial<Config> {
+  const plugins: PluginsConfig = [
+    ...(config.plugins || []),
+    surfaceComponentsPlugin(options),
+  ];
+
+  return {
+    ...config,
+    plugins,
+  };
+}
+
+export function surfaceComponentsPlugin(options: Partial<SurfaceComponentsOptions> = {}) {
+  return plugin(function ({ addComponents, theme }) {
+    const components: CSSRuleObject[] = makeSurfaceComponents(options, theme);
+    addComponents(components);
+  } as PluginCreator);
+}
+
+function makeSurfaceComponents(options: Partial<SurfaceComponentsOptions>, theme: PluginThemeAPI): CSSRuleObject[] {
+  // TODO: consider tailwindcss prefix
+  const $options = defaultSurfaceComponentsOptions(options);
+
+  const components: CSSRuleObject[] = [];
+
+  // all colors
+  const allColors: Record<string, boolean> = {};
+  for (const name of Object.keys(theme('colors', defaultColors))) {
+    allColors[name] = true;
+  }
+  for (const name of Object.keys(theme('extend.colors', defaultColors))) {
+    allColors[name] = true;
+  }
+
+  // color pairs
+  const pairs: Record<string, string> = {};
+  for (const name of Object.keys(allColors)) {
+    if (allColors[name] && allColors[`on-${name}`]) {
+      pairs[name] = `on-${name}`;
+    }
+  }
+
+  // TODO: determine pair of special colors
+  // - primary-fixed-dim
+  // - on-primary-fixed-variant
+  // - secondary-fixed-dim
+  // - on-secondary-fixed-variant
+  // - tertiary-fixed-dim
+  // - on-tertiary-fixed-variant
+
+  for (const colorName of Object.keys(pairs)) {
+    components.push(assembleSurfaceComponent($options, colorName, pairs[colorName]));
+  }
+
+  return components;
+}
+
+function assembleSurfaceComponent(options: SurfaceComponentsOptions, colorName: string, onColorName: string): CSSRuleObject {
+  const { bgPrefix, textPrefix, surfacePrefix } = options;
+
+  if (surfacePrefix === bgPrefix) {
+    // extend bg- with text-on-
+    return {
+      [`.${bgPrefix}${colorName}`]: {
+        [`@apply ${textPrefix}${onColorName}`]: {},
+      },
+    };
+  }
+
+  // combine bg- and text-on-
+  return {
+    [`.${surfacePrefix}${colorName}`]: {
+      [`@apply ${bgPrefix}${colorName} ${textPrefix}${onColorName}`]: {},
+    },
+  };
+}
+
+function defaultSurfaceComponentsOptions(options: Partial<SurfaceComponentsOptions>): SurfaceComponentsOptions {
+  return {
+    surfacePrefix: options.surfacePrefix ?? 'surface-',
+    bgPrefix: options.bgPrefix ?? 'bg-',
+    textPrefix: options.textPrefix ?? 'text-',
+  };
+}

--- a/packages/theme-builder/src/tailwind/plugin-surfaces.ts
+++ b/packages/theme-builder/src/tailwind/plugin-surfaces.ts
@@ -2,6 +2,7 @@ import {
   type Config,
   type PluginsConfig,
   type PluginCreator,
+  type PluginConfigAPI,
   type PluginThemeAPI,
 
   defaultColors,
@@ -38,15 +39,14 @@ export function withSurfaceComponents(config: Partial<Config> = {}, options: Par
 }
 
 export function surfaceComponentsPlugin(options: Partial<SurfaceComponentsOptions> = {}) {
-  return plugin(function ({ addComponents, theme }) {
-    const components: CSSRuleObject[] = makeSurfaceComponents(options, theme);
+  return plugin(function ({ addComponents, config, theme }) {
+    const components: CSSRuleObject[] = makeSurfaceComponents(options, config, theme);
     addComponents(components);
   } as PluginCreator);
 }
 
-function makeSurfaceComponents(options: Partial<SurfaceComponentsOptions>, theme: PluginThemeAPI): CSSRuleObject[] {
-  // TODO: consider tailwindcss prefix
-  const $options = defaultSurfaceComponentsOptions(options);
+function makeSurfaceComponents(options: Partial<SurfaceComponentsOptions>, config: PluginConfigAPI, theme: PluginThemeAPI): CSSRuleObject[] {
+  const $options = defaultSurfaceComponentsOptions(options, config);
 
   const components: CSSRuleObject[] = [];
 
@@ -110,10 +110,11 @@ function makeSurfaceName(colorName: string, prefix: string): string {
   return `${prefix}${colorName}`;
 }
 
-function defaultSurfaceComponentsOptions(options: Partial<SurfaceComponentsOptions>): SurfaceComponentsOptions {
+function defaultSurfaceComponentsOptions(options: Partial<SurfaceComponentsOptions>, config: PluginConfigAPI): SurfaceComponentsOptions {
+  const tw: string = config('prefix', '');
   return {
     surfacePrefix: options.surfacePrefix ?? 'surface-',
-    bgPrefix: options.bgPrefix ?? 'bg-',
-    textPrefix: options.textPrefix ?? 'text-',
+    bgPrefix: options.bgPrefix ?? `${tw}bg-`,
+    textPrefix: options.textPrefix ?? `${tw}text-`,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Tailwind CSS configuration with more flexible surface component generation.
	- Added support for dynamic surface component styling based on color themes.

- **Improvements**
	- Expanded type definitions for plugin configurations.
	- Improved modularity of theme builder exports.
	- More configurable color and surface component handling.

- **Technical Updates**
	- Updated type exports and import mechanisms.
	- Introduced new plugin for surface component generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->