### PR TITLE
feat(theme-builder): introduce utils package

### DIFF
--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -22,6 +22,11 @@
         "require": "./dist/index.cjs"
       }
     },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.mjs",
+      "require": "./dist/utils.cjs"
+    },
     "./core": {
       "types": "./dist/core.d.ts",
       "import": "./dist/core.mjs",

--- a/packages/theme-builder/src/core/utils.ts
+++ b/packages/theme-builder/src/core/utils.ts
@@ -5,7 +5,7 @@ export type Prettify<T> = {
 };
 
 /** @returns the type of a property of the object */
-export type PropType<T, K extends keyof T> = T[K];
+export type PropertyType<T, K extends keyof T> = T[K];
 
 /** @returns a given string converted to kebab-case */
 export function kebabCase(s: string): string {

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -1,8 +1,4 @@
 export {
-  type PropType,
-} from './core/utils';
-
-export {
   type Color,
   type HexColor,
   Hct,

--- a/packages/theme-builder/src/tailwind/common.ts
+++ b/packages/theme-builder/src/tailwind/common.ts
@@ -1,5 +1,5 @@
 import {
-  type PropType,
+  type PropertyType,
 } from '../core/utils';
 
 import {
@@ -15,12 +15,12 @@ export {
   type PluginCreator,
 } from 'tailwindcss/types/config';
 
-export type PluginsConfig = PropType<Config, 'plugins'>;
-export type SafelistConfig = PropType<Config, 'safelist'>;
-export type ThemeConfig = PropType<Config, 'theme'>;
+export type PluginsConfig = PropertyType<Config, 'plugins'>;
+export type SafelistConfig = PropertyType<Config, 'safelist'>;
+export type ThemeConfig = PropertyType<Config, 'theme'>;
 
-export type PluginThemeAPI = PropType<PluginAPI, 'theme'>;
-export type PluginConfigAPI = PropType<PluginAPI, 'config'>;
+export type PluginThemeAPI = PropertyType<PluginAPI, 'theme'>;
+export type PluginConfigAPI = PropertyType<PluginAPI, 'config'>;
 
 /*
  * Data

--- a/packages/theme-builder/src/utils.ts
+++ b/packages/theme-builder/src/utils.ts
@@ -1,0 +1,1 @@
+export * from './core/utils';


### PR DESCRIPTION
remove type PropType<T> from tailwind and export as PropertyType from utils.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added export for `utils` module in theme builder package

- **Refactor**
	- Renamed type `PropType` to `PropertyType` across multiple files
	- Updated type signatures in Tailwind configuration and plugin API types

- **Chores**
	- Bumped package version from `0.5.3` to `0.5.4`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->