### PR TITLE
feat(theme-builder): tailwind: introduce universal rgb() helper

### DIFF
--- a/packages/theme-builder/src/tailwind-theme.ts
+++ b/packages/theme-builder/src/tailwind-theme.ts
@@ -29,7 +29,7 @@ import {
 
 import {
   rgbFromHct,
-} from './tailwind-common';
+} from './tailwind/index';
 
 import {
   type Shade,

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -16,10 +16,6 @@ export {
 } from './dynamic-color-data';
 
 export {
-  rgbFromHct,
-} from './tailwind-common';
-
-export {
   type Shade,
   type Shades,
 

--- a/packages/theme-builder/src/tailwind/index.ts
+++ b/packages/theme-builder/src/tailwind/index.ts
@@ -6,3 +6,4 @@ export {
 
 export * from './plugin-print-mode';
 export * from './plugin-surfaces';
+export * from './rgb';

--- a/packages/theme-builder/src/tailwind/rgb.ts
+++ b/packages/theme-builder/src/tailwind/rgb.ts
@@ -1,17 +1,20 @@
-// imports
-//
 import {
+  type Color,
   Hct,
 
+  argb,
   argbFromHct,
   splitArgb,
 } from '../core/colors';
 
-// rgbFromArgb for tailwindcss color variables.
+/** @returns RGB representation of the given ARGB number for tailwindcss color variables. */
 export const rgbFromArgb = (argb: number) => {
   const { r, g, b } = splitArgb(argb);
   return `${r} ${g} ${b}`;
 };
 
-// rgbFromHct for tailwindcss color variables.
+/** @returns RGB representation of the given {@link Hct} color for tailwindcss color variables. */
 export const rgbFromHct = (c: Hct) => rgbFromArgb(argbFromHct(c));
+
+/** @returns RGB representation of the given {@link Color} for tailwindcss color variables. */
+export const rgb = (c: Color) => rgbFromArgb(argb(c));

--- a/packages/theme-builder/src/tailwind/rgb.ts
+++ b/packages/theme-builder/src/tailwind/rgb.ts
@@ -5,7 +5,7 @@ import {
 
   argbFromHct,
   splitArgb,
-} from './core/colors';
+} from '../core/colors';
 
 // rgbFromArgb for tailwindcss color variables.
 export const rgbFromArgb = (argb: number) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Reorganized color conversion utility functions from `tailwind-common.ts` to a new `tailwind/rgb.ts` module
	- Updated import statements to reflect the new module location
	- Added a new `rgb()` function for color conversion

- **Chores**
	- Cleaned up and restructured color-related code organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->