### PR TITLE
poupe-vue: fix type-check errors

### DIFF
--- a/packages/poupe-vue/tsconfig.app.json
+++ b/packages/poupe-vue/tsconfig.app.json
@@ -2,6 +2,7 @@
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "include": [
     "env.d.ts",
+    "tailwind.config.*",
     "src/**/*.ts",
     "src/**/*.vue",
   ],

--- a/packages/poupe-vue/tsconfig.app.json
+++ b/packages/poupe-vue/tsconfig.app.json
@@ -11,6 +11,10 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
+    "lib": [
+      "es2021"
+    ],
+
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/poupe-vue/tsconfig.vitest.json
+++ b/packages/poupe-vue/tsconfig.vitest.json
@@ -5,7 +5,6 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
 
-    "lib": [],
     "types": ["node", "jsdom"]
   }
 }

--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/dynamic-color-data.ts
+++ b/packages/theme-builder/src/dynamic-color-data.ts
@@ -1,5 +1,5 @@
 import {
-  ColorGroup,
+  type ColorGroup,
   MaterialDynamicColors,
   SchemeContent,
   SchemeExpressive,
@@ -11,8 +11,8 @@ import {
 } from '@material/material-color-utilities';
 
 import {
+  type standardDynamicSchemeFactory,
   hct,
-  standardDynamicSchemeFactory,
 } from './core';
 
 // CustomDynamicColor

--- a/packages/theme-builder/src/dynamic-color.ts
+++ b/packages/theme-builder/src/dynamic-color.ts
@@ -22,12 +22,12 @@ import {
 } from './core/utils';
 
 import {
-  StandardDynamicColorKey,
-  CustomDynamicColorKey,
+  type CustomDynamicColorKey,
+  type StandardDynamicColorKey,
+  type StandardPaletteKey,
 
   standardDynamicColors,
   customDynamicColors,
-  StandardPaletteKey,
   standardPaletteKeyColors,
 } from './dynamic-color-data';
 

--- a/packages/theme-builder/src/dynamic-theme.ts
+++ b/packages/theme-builder/src/dynamic-theme.ts
@@ -17,14 +17,14 @@ import {
 
 import {
   type StandardDynamicSchemeKey,
+  type StandardDynamicColorKey,
+  type StandardPaletteKey,
   type CustomDynamicColorKey,
 
   customDynamicColors,
   standardDynamicColorKeys,
-  StandardDynamicColorKey,
   standardDynamicSchemes,
   standardPaletteKeys,
-  StandardPaletteKey,
 } from './dynamic-color-data';
 
 import {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package version for `@poupe/theme-builder` from `0.5.5` to `0.5.6`

- **Refactor**
  - Enhanced TypeScript type declarations in theme-builder package
  - Updated TypeScript configuration for improved type checking and library support

- **Documentation**
  - Improved type annotations for better code clarity and type safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->