### PR TITLE
feat(poupe-vue): components: add initial <placeholder />

### DIFF
--- a/packages/poupe-vue/package.json
+++ b/packages/poupe-vue/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@poupe/theme-builder": "workspace:",
     "@unhead/vue": "^1.11.18",
+    "tailwind-variants": "^0.3.1",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/packages/poupe-vue/src/app.vue
+++ b/packages/poupe-vue/src/app.vue
@@ -15,7 +15,10 @@ useHead({
 <template>
   <div class="flex h-screen items-center justify-center">
     <div class="w-full max-w-2xl">
-      <placeholder class="opacity-50 rounded-xl" />
+      <placeholder
+        class="opacity-50"
+        rounded="xl"
+      />
     </div>
   </div>
 </template>

--- a/packages/poupe-vue/src/app.vue
+++ b/packages/poupe-vue/src/app.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { useHead } from '@unhead/vue';
 
+import {
+  Placeholder,
+} from './components';
+
 useHead({
   bodyAttrs: {
     class: 'surface',
@@ -9,7 +13,9 @@ useHead({
 </script>
 
 <template>
-  <div class="text-3xl font-bold">
-    Hello, World
+  <div class="flex h-screen items-center justify-center">
+    <div class="w-full max-w-2xl">
+      <placeholder class="opacity-50 rounded-xl" />
+    </div>
   </div>
 </template>

--- a/packages/poupe-vue/src/components/index.ts
+++ b/packages/poupe-vue/src/components/index.ts
@@ -1,0 +1,4 @@
+export {
+  default as Placeholder,
+  type PlaceholderProps,
+} from './placeholder.vue';

--- a/packages/poupe-vue/src/components/placeholder.vue
+++ b/packages/poupe-vue/src/components/placeholder.vue
@@ -1,0 +1,120 @@
+<script lang="ts">
+import {
+  tv,
+  type VariantProps,
+} from './variants';
+
+const placeholder = tv({
+  slots: {
+    wrapper: 'overflow-hidden',
+    pattern: 'w-full h-full',
+  },
+  variants: {
+    border: {
+      solid: {
+        wrapper: 'border-solid border',
+      },
+      none: {
+        wrapper: 'border-none',
+      },
+      dashed: {
+        wrapper: 'border-dashed border',
+      },
+    },
+    color: {
+      current: {
+        wrapper: 'border-current',
+        pattern: 'stroke-current',
+      },
+      ['outline-variant']: {
+        wrapper: 'border-outline-variant',
+        pattern: 'stroke-outline-variant',
+      },
+      outline: {
+        wrapper: 'border-outline',
+        pattern: 'stroke-outline',
+      },
+      primary: {
+        wrapper: 'border-primary',
+        pattern: 'stroke-primary',
+      },
+      secondary: {
+        wrapper: 'border-secondary',
+        pattern: 'stroke-secondary',
+      },
+      tertiary: {
+        wrapper: 'border-tertiary',
+        pattern: 'stroke-tertiary',
+      },
+      error: {
+        wrapper: 'border-error',
+        pattern: 'stroke-error',
+      },
+    },
+  },
+});
+
+type PlaceholderVariantProps = VariantProps<typeof placeholder>;
+
+/** Placeholder component props */
+export type PlaceholderProps = {
+  /** rhombus width. @defaultValue 10 */
+  rw?: number
+  /** rhombus height. @defaultValue 20 */
+  rh?: number
+
+  /** placeholder border. @defaultValue `'dashed'` */
+  border?: PlaceholderVariantProps['border']
+  /** pattern and border color. @defaultValue '`outline-variant`' */
+  color?: PlaceholderVariantProps['color']
+};
+</script>
+
+<script setup lang="ts">
+import { computed, useId } from 'vue';
+
+const props = withDefaults(defineProps<PlaceholderProps>(), {
+  rw: 10,
+  rh: 20,
+  border: 'dashed' as const,
+  color: 'outline-variant' as const,
+});
+
+const id = useId();
+const variants = computed(() => placeholder({
+  border: props.border,
+  color: props.color,
+}));
+
+</script>
+
+<template>
+  <div :class="variants.wrapper()">
+    <svg :class="variants.pattern()">
+      <defs>
+        <pattern
+          :id="id"
+          x="0"
+          y="0"
+          :width="rw"
+          :height="rh"
+          patternUnits="userSpaceOnUse"
+        >
+          <path
+            :d="`M0 0 ${rw} ${rh} M${rw} 0 0 ${rh}`"
+            stroke-width="1px"
+          />
+        </pattern>
+      </defs>
+
+      <rect
+        stroke="none"
+        :fill="`url(#${id})`"
+        width="100%"
+        height="100%"
+      />
+    </svg>
+
+    <slot />
+  </div>
+</template>

--- a/packages/poupe-vue/src/components/placeholder.vue
+++ b/packages/poupe-vue/src/components/placeholder.vue
@@ -90,7 +90,10 @@ const variants = computed(() => placeholder({
 
 <template>
   <div :class="variants.wrapper()">
-    <svg :class="variants.pattern()">
+    <svg
+      :class="variants.pattern()"
+      aria-hidden="true"
+    >
       <defs>
         <pattern
           :id="id"
@@ -103,6 +106,7 @@ const variants = computed(() => placeholder({
           <path
             :d="`M0 0 ${rw} ${rh} M${rw} 0 0 ${rh}`"
             stroke-width="1px"
+            vector-effect="non-scaling-stroke"
           />
         </pattern>
       </defs>

--- a/packages/poupe-vue/src/components/placeholder.vue
+++ b/packages/poupe-vue/src/components/placeholder.vue
@@ -2,7 +2,17 @@
 import {
   tv,
   type VariantProps,
+
+  onSlot,
+  roundedVariants,
+  shadowVariants,
 } from './variants';
+
+const borderVariants = {
+  solid: 'border-solid border',
+  none: 'border-none',
+  dashed: 'border-dashed border',
+};
 
 const placeholder = tv({
   slots: {
@@ -10,17 +20,7 @@ const placeholder = tv({
     pattern: 'w-full h-full',
   },
   variants: {
-    border: {
-      solid: {
-        wrapper: 'border-solid border',
-      },
-      none: {
-        wrapper: 'border-none',
-      },
-      dashed: {
-        wrapper: 'border-dashed border',
-      },
-    },
+    border: onSlot('wrapper', borderVariants),
     color: {
       current: {
         wrapper: 'border-current',
@@ -51,6 +51,8 @@ const placeholder = tv({
         pattern: 'stroke-error',
       },
     },
+    rounded: onSlot('wrapper', roundedVariants),
+    shadow: onSlot('wrapper', shadowVariants),
   },
 });
 
@@ -67,6 +69,10 @@ export type PlaceholderProps = {
   border?: PlaceholderVariantProps['border']
   /** pattern and border color. @defaultValue '`outline-variant`' */
   color?: PlaceholderVariantProps['color']
+  /** rounded corners. @defaultValue `'xl'` */
+  rounded?: PlaceholderVariantProps['rounded']
+  /** shadow. @defaultValue `'none'` */
+  shadow?: PlaceholderVariantProps['shadow']
 };
 </script>
 
@@ -78,12 +84,16 @@ const props = withDefaults(defineProps<PlaceholderProps>(), {
   rh: 20,
   border: 'dashed' as const,
   color: 'outline-variant' as const,
+  rounded: 'xl' as const,
+  shadow: 'none' as const,
 });
 
 const id = useId();
 const variants = computed(() => placeholder({
   border: props.border,
   color: props.color,
+  rounded: props.rounded,
+  shadow: props.shadow,
 }));
 
 </script>

--- a/packages/poupe-vue/src/components/variants.ts
+++ b/packages/poupe-vue/src/components/variants.ts
@@ -1,0 +1,1 @@
+export { tv, type VariantProps } from 'tailwind-variants';

--- a/packages/poupe-vue/src/components/variants.ts
+++ b/packages/poupe-vue/src/components/variants.ts
@@ -1,1 +1,17 @@
+import { unsafeKeys } from '../utils/utils';
+
+import {
+  type ClassValue,
+} from 'tailwind-variants';
+
 export { tv, type VariantProps } from 'tailwind-variants';
+
+/** @returns a variant applied to the specified slot */
+export const onSlot = <K extends string> (slot: string, variants: Record<K, ClassValue>) => {
+  type T = { [slot: string]: ClassValue };
+  const out: Partial<Record<K, T>> = {};
+  for (const name of unsafeKeys(variants)) {
+    out[name] = { [slot]: variants[name] };
+  }
+  return out as Record<K, T>;
+};

--- a/packages/poupe-vue/src/components/variants.ts
+++ b/packages/poupe-vue/src/components/variants.ts
@@ -15,3 +15,29 @@ export const onSlot = <K extends string> (slot: string, variants: Record<K, Clas
   }
   return out as Record<K, T>;
 };
+
+export const roundedVariants = {
+  full: 'rounded-full',
+  none: 'rounded-none',
+
+  xs: 'rounded-sm',
+  sm: 'rounded',
+  md: 'rounded-md',
+  lg: 'rounded-lg',
+  xl: 'rounded-xl',
+  ['2xl']: 'rounded-2xl',
+  ['3xl']: 'rounded-3xl',
+};
+
+export const shadowVariants = {
+  current: 'shadow-shadow shadow',
+  none: 'shadow-none',
+
+  xs: 'shadow-shadow shadow-sm',
+  sm: 'shadow-shadow shadow',
+  md: 'shadow-shadow shadow-md',
+  lg: 'shadow-shadow shadow-lg',
+  xl: 'shadow-shadow shadow-xl',
+  ['2xl']: 'shadow-shadow shadow-2xl',
+  inner: 'shadow-shadow shadow-inner',
+};

--- a/packages/poupe-vue/src/utils/utils.ts
+++ b/packages/poupe-vue/src/utils/utils.ts
@@ -1,0 +1,2 @@
+/** @returns a typed array of keys of the object */
+export const unsafeKeys = Object.keys as <T>(object: T) => Array<keyof T>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@unhead/vue':
         specifier: ^1.11.18
         version: 1.11.18(vue@3.5.13(typescript@5.7.3))
+      tailwind-variants:
+        specifier: ^0.3.1
+        version: 0.3.1(tailwindcss@3.4.17)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.7.3)
@@ -4335,6 +4338,15 @@ packages:
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
+
+  tailwind-merge@2.5.4:
+    resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
+
+  tailwind-variants@0.3.1:
+    resolution: {integrity: sha512-krn67M3FpPwElg4FsZrOQd0U26o7UDH/QOkK8RNaiCCrr052f6YJPBUfNKnPo/s/xRzNPtv1Mldlxsg8Tb46BQ==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwindcss: '*'
 
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
@@ -9643,6 +9655,13 @@ snapshots:
       tslib: 2.8.1
 
   system-architecture@0.1.0: {}
+
+  tailwind-merge@2.5.4: {}
+
+  tailwind-variants@0.3.1(tailwindcss@3.4.17):
+    dependencies:
+      tailwind-merge: 2.5.4
+      tailwindcss: 3.4.17
 
   tailwindcss@3.4.17:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `Placeholder` component with customizable styling and dynamic SVG pattern.
	- Integrated `tailwind-variants` for flexible component styling.

- **Dependencies**
	- Added `tailwind-variants` library version `^0.3.1`.

- **Enhancements**
	- Improved import process for the `Placeholder` component and its props.
	- Introduced a utility function for enhanced type safety when retrieving object keys.
	- Added new variant functionalities for rounded corners and shadows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->