### PR TITLE
add jsdoc badges to README files

### DIFF
--- a/packages/poupe-nuxt/README.md
+++ b/packages/poupe-nuxt/README.md
@@ -1,23 +1,15 @@
-<!--
-Get your module up and running quickly.
-
-Find and replace all on all files (CMD+SHIFT+F):
-- Name: My Module
-- Package name: my-module
-- Description: My new Nuxt module
--->
-
-# My Module
+# Poupe UI
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
+[![jsDocs.io][jsdoc-src]][jsdoc-href]
 
-My new Nuxt module for doing amazing things.
+Poupe UI for Nuxt.
 
 - [✨ &nbsp;Release Notes](/CHANGELOG.md)
-<!-- - [🏀 Online playground](https://stackblitz.com/github/your-org/my-module?file=playground%2Fapp.vue) -->
+<!-- - [🏀 Online playground](https://stackblitz.com/github/your-org/@poupe/nuxt?file=playground%2Fapp.vue) -->
 <!-- - [📖 &nbsp;Documentation](https://example.com) -->
 
 ## Features
@@ -32,10 +24,10 @@ My new Nuxt module for doing amazing things.
 Install the module to your Nuxt application with one command:
 
 ```bash
-npx nuxi module add my-module
+npx nuxi module add @poupe/nuxt
 ```
 
-That's it! You can now use My Module in your Nuxt app ✨
+That's it! You can now use Poupe UI in your Nuxt app ✨
 
 
 ## Contribution
@@ -71,14 +63,17 @@ That's it! You can now use My Module in your Nuxt app ✨
 
 
 <!-- Badges -->
-[npm-version-src]: https://img.shields.io/npm/v/my-module/latest.svg?style=flat&colorA=020420&colorB=00DC82
-[npm-version-href]: https://npmjs.com/package/my-module
+[npm-version-src]: https://img.shields.io/npm/v/@poupe/nuxt/latest.svg?style=flat&colorA=020420&colorB=00DC82
+[npm-version-href]: https://npmjs.com/package/@poupe/nuxt
 
-[npm-downloads-src]: https://img.shields.io/npm/dm/my-module.svg?style=flat&colorA=020420&colorB=00DC82
-[npm-downloads-href]: https://npmjs.com/package/my-module
+[npm-downloads-src]: https://img.shields.io/npm/dm/@poupe/nuxt.svg?style=flat&colorA=020420&colorB=00DC82
+[npm-downloads-href]: https://npmjs.com/package/@poupe/nuxt
 
-[license-src]: https://img.shields.io/npm/l/my-module.svg?style=flat&colorA=020420&colorB=00DC82
-[license-href]: https://npmjs.com/package/my-module
+[license-src]: https://img.shields.io/npm/l/@poupe/nuxt.svg?style=flat&colorA=020420&colorB=00DC82
+[license-href]: https://npmjs.com/package/@poupe/nuxt
 
 [nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt.js
 [nuxt-href]: https://nuxt.com
+
+[jsdoc-src]: https://img.shields.io/badge/jsDocs.io-reference-blue
+[jsdoc-href]: https://www.jsdocs.io/package/@poupe/nuxt

--- a/packages/poupe-vue/README.md
+++ b/packages/poupe-vue/README.md
@@ -1,5 +1,7 @@
 # poupe-vue
 
+[![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@poupe/vue)
+
 This template should help get you started developing with Vue 3 in Vite.
 
 ## Recommended IDE Setup

--- a/packages/theme-builder/README.md
+++ b/packages/theme-builder/README.md
@@ -1,0 +1,1 @@
+[![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@poupe/theme-builder)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README for `@poupe/nuxt` package, rebranding from "My Module" to "Poupe UI" and modifying installation commands.
	- Added documentation badge for `poupe-vue` package, linking to jsDocs.io reference.
	- Added documentation badge for `@poupe/theme-builder` package, linking to jsDocs.io reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->