### PR TITLE
feat(theme-builder): tailwind: export TailwindThemeOptions type

### DIFF
--- a/packages/poupe-nuxt/package.json
+++ b/packages/poupe-nuxt/package.json
@@ -59,7 +59,7 @@
     "vue-tsc": "^2.2.0"
   },
   "peerDependencies": {
-    "@poupe/theme-builder": "^0.5.6",
+    "@poupe/theme-builder": "^0.5.7",
     "@poupe/vue": "^0.1.0"
   }
 }

--- a/packages/poupe-vue/package.json
+++ b/packages/poupe-vue/package.json
@@ -66,7 +66,7 @@
     "vue-tsc": "^2.2.0"
   },
   "peerDependencies": {
-    "@poupe/theme-builder": "^0.5.6",
+    "@poupe/theme-builder": "^0.5.7",
     "tailwindcss": "^3.4.17"
   }
 }

--- a/packages/theme-builder/package.json
+++ b/packages/theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/theme-builder/src/tailwind.ts
+++ b/packages/theme-builder/src/tailwind.ts
@@ -25,6 +25,8 @@ export {
 } from './tailwind-shades';
 
 export {
+  type TailwindThemeOptions,
+
   makeColorConfig,
   makeCSSTheme,
 } from './tailwind-theme';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Exported a new type `TailwindThemeOptions` in the theme builder package

- **Chores**
	- Updated `@poupe/theme-builder` package version from 0.5.6 to 0.5.7
	- Updated peer dependencies in `@poupe/nuxt` and `@poupe/vue` packages to use the new theme builder version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->