### PR TITLE
feat(poupe-vue): resolver: introduce contentPath() and contentGlobs()

### DIFF
--- a/packages/poupe-vue/package.json
+++ b/packages/poupe-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/vue",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/poupe-vue/src/resolver.ts
+++ b/packages/poupe-vue/src/resolver.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'pathe';
 import type { ComponentResolverObject } from 'unplugin-vue-components';
 
 export const components = [
@@ -26,5 +27,17 @@ export const createResolver = (options: ResolverOptions = {}): ComponentResolver
 };
 
 export default createResolver;
+
+/** @returns the directory path to the `@poupe/vue` package */
+export const contentPath = () => dirname(new URL(import.meta.url).pathname);
+
+/** @returns the glob patterns needed by tailwindcss to scan classes */
+export const contentGlobs = (): string[] => {
+  const path = contentPath();
+  return [
+    `${path}/index.mjs`,
+    `${path}/**/*.vue`,
+  ];
+};
 
 const deprefix = (name: string, prefix: string) => name.startsWith(prefix) ? name.slice(prefix.length) : undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       npm-run-all2:
         specifier: ^7.0.2
         version: 7.0.2
+      pathe:
+        specifier: ^2.0.2
+        version: 2.0.2
       postcss:
         specifier: ^8.5.1
         version: 8.5.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated package version from 0.1.1 to 0.1.2.
- **New Features**
	- Added functions to dynamically resolve content paths and generate patterns for Tailwind CSS integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->