### PR TITLE
feat(poupe-vue): change Button to use `containerVariants` and allow `${color}-container` in `surfaceVariants`

### DIFF
--- a/packages/poupe-vue/src/components/button.vue
+++ b/packages/poupe-vue/src/components/button.vue
@@ -7,7 +7,7 @@ import {
   borderVariants,
   roundedVariants,
   shadowVariants,
-  surfaceVariants,
+  containerVariants,
 } from './variants';
 
 const defaultVariantProps = {
@@ -32,7 +32,7 @@ const button = tv({
     wrapper: '',
   },
   variants: {
-    surface: onSlot('wrapper', surfaceVariants),
+    surface: onSlot('wrapper', containerVariants),
     border: onSlot('wrapper', borderVariants),
     rounded: onSlot('wrapper', roundedVariants),
     shadow: onSlot('wrapper', shadowVariants),
@@ -68,10 +68,10 @@ import { computed } from 'vue';
 const props = defineProps<ButtonProps>();
 
 const variants = computed(() => button({
+  surface: props.surface,
   border: props.border,
   rounded: props.rounded,
   shadow: props.shadow,
-  surface: props.surface,
   size: props.size,
   expand: props.expand,
 }));

--- a/packages/poupe-vue/src/components/variants.ts
+++ b/packages/poupe-vue/src/components/variants.ts
@@ -63,6 +63,11 @@ export const colorSurfaceVariants = {
   ['secondary-fixed']: 'bg-secondary-fixed text-on-secondary-fixed border-on-secondary-fixed',
   ['tertiary-fixed']: 'bg-tertiary-fixed text-on-tertiary-fixed border-on-tertiary-fixed',
 
+  ['primary-container']: 'bg-primary-container text-on-primary-container border-on-primary-container',
+  ['secondary-container']: 'bg-secondary-container text-on-secondary-container border-on-secondary-container',
+  ['tertiary-container']: 'bg-tertiary-container text-on-tertiary-container border-on-tertiary-container',
+  ['error-container']: 'bg-error-container text-on-error-container border-on-error-container',
+
   inverse: 'bg-inverse-surface text-on-inverse-surface border-on-inverse-surface',
 };
 
@@ -77,11 +82,6 @@ export const surfaceVariants = {
 
 export const containerVariants = {
   ...colorSurfaceVariants,
-
-  ['primary-container']: 'bg-primary-container text-on-primary-container border-on-primary-container',
-  ['secondary-container']: 'bg-secondary-container text-on-secondary-container border-on-secondary-container',
-  ['tertiary-container']: 'bg-tertiary-container text-on-tertiary-container border-on-tertiary-container',
-  ['error-container']: 'bg-error-container text-on-error-container border-on-error-container',
 
   lowest: 'bg-surface-container-lowest text-on-surface-container-lowest border-on-surface-container-lowest',
   low: 'bg-surface-container-low text-on-surface-container-low border-on-surface-container-low',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced additional styling options for button components, offering enhanced color themes and visual variety.
  
- **Refactor**
  - Streamlined how button style variants are determined, resulting in more consistent and predictable appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->