### PR TITLE
feat(poupe-vue): variants: enhance onSlot() to allow a list of slots

### DIFF
--- a/packages/poupe-vue/src/components/variants/__tests__/onslot.spec.ts
+++ b/packages/poupe-vue/src/components/variants/__tests__/onslot.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { onSlot } from '..';
+
+describe('onSlot', () => {
+  it('applies a variant to a single slot', () => {
+    const variants = {
+      foo: 'bar',
+    };
+    const result = onSlot('slot', variants);
+    expect(result).toEqual({
+      foo: {
+        slot: 'bar',
+      },
+    });
+  });
+
+  it('applies a variant to multiple slots', () => {
+    const variants = {
+      foo: 'bar',
+    };
+    const result = onSlot(['slot1', 'slot2'], variants);
+    expect(result).toEqual({
+      foo: {
+        slot1: 'bar',
+        slot2: 'bar',
+      },
+    });
+  });
+
+  it('handles multiple variants', () => {
+    const variants = {
+      foo: 'bar',
+      baz: 'qux',
+    };
+    const result = onSlot('slot', variants);
+    expect(result).toEqual({
+      foo: {
+        slot: 'bar',
+      },
+      baz: {
+        slot: 'qux',
+      },
+    });
+  });
+
+  it('handles empty variants object', () => {
+    const variants = {};
+    const result = onSlot('slot', variants);
+    expect(result).toEqual({});
+  });
+});

--- a/packages/poupe-vue/src/components/variants/index.ts
+++ b/packages/poupe-vue/src/components/variants/index.ts
@@ -8,13 +8,22 @@ export { tv, type VariantProps } from 'tailwind-variants';
 export { twMerge } from 'tailwind-merge';
 
 /** @returns a variant applied to the specified slot */
-export const onSlot = <K extends string> (slot: string, variants: Record<K, ClassValue>) => {
-  type T = { [slot: string]: ClassValue };
+export const onSlot = <K extends string> (slot: string | string[], variants: Record<K, ClassValue>) => {
+  const slots = Array.isArray(slot) ? slot : [slot];
+
+  type S = typeof slots[number];
+  type T = { [slot in S]: ClassValue };
+
   const out: Partial<Record<K, T>> = {};
   for (const name of unsafeKeys(variants)) {
-    out[name] = { [slot]: variants[name] };
+    const v: Record<S, ClassValue> = {};
+    for (const s of slots) {
+      v[s] = variants[name];
+    }
+    out[name] = v;
   }
-  return out as Record<K, T>;
+
+  return out as { [slot in K]: T };
 };
 
 export const borderVariants = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the variant application functionality to accept both single and multiple slot inputs, offering improved flexibility when assigning variants.
- **Tests**
	- Added a comprehensive test suite to ensure the variant mapping behaves correctly in various scenarios, including single, multiple, and empty variant cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->