### PR TITLE
feat(poupe-vue): move `contentGlobs` to ./config [BREAKING]

### DIFF
--- a/packages/poupe-nuxt/src/components.ts
+++ b/packages/poupe-nuxt/src/components.ts
@@ -6,8 +6,6 @@ import type { ModuleOptions } from './config';
 
 export const COMPONENTS_PACKAGE = '@poupe/vue';
 
-export { contentGlobs } from '@poupe/vue/resolver';
-
 export const setupComponents = (options: ModuleOptions): void => {
   const { prefix: $prefix = DEFAULT_PREFIX } = options;
   const prefix = normalizedComponentPrefix($prefix);

--- a/packages/poupe-nuxt/src/tailwind.ts
+++ b/packages/poupe-nuxt/src/tailwind.ts
@@ -2,9 +2,10 @@ import { defu } from 'defu';
 import { addTemplate, installModule } from '@nuxt/kit';
 import type { ModuleOptions as TailwindModuleOptions } from '@nuxtjs/tailwindcss';
 
+import { contentGlobs } from '@poupe/vue/config';
+
 import type { ModuleOptions, Nuxt } from './config';
 import { createDefaultResolver, stringify } from './utils';
-import { contentGlobs } from './components';
 
 const POUPE_TAILWIND_CONFIG_FILENAME = 'poupe-tailwind.config.ts';
 

--- a/packages/poupe-vue/package.json
+++ b/packages/poupe-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/vue",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "type": "module",
   "description": "",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/poupe-vue/src/config.ts
+++ b/packages/poupe-vue/src/config.ts
@@ -1,3 +1,5 @@
+import { dirname } from 'pathe';
+
 import FormsPlugin from '@tailwindcss/forms';
 import ScrollbarPlugin from 'tailwind-scrollbar';
 
@@ -6,3 +8,14 @@ export const tailwindPlugins = [
   FormsPlugin,
   ScrollbarPlugin,
 ];
+
+/** @returns the directory path to the `@poupe/vue` package */
+export const contentPath = () => dirname(new URL(import.meta.url).pathname);
+
+/** @returns the glob patterns needed by tailwindcss to scan classes */
+export const contentGlobs = (): string[] => {
+  const path = contentPath();
+  return [
+    `${path}/index.mjs`,
+  ];
+};

--- a/packages/poupe-vue/src/resolver.ts
+++ b/packages/poupe-vue/src/resolver.ts
@@ -1,4 +1,3 @@
-import { dirname } from 'pathe';
 import type { ComponentResolverObject } from 'unplugin-vue-components';
 
 export const components = [
@@ -44,17 +43,5 @@ export const createResolver = (options: ResolverOptions = {}): ComponentResolver
 };
 
 export default createResolver;
-
-/** @returns the directory path to the `@poupe/vue` package */
-export const contentPath = () => dirname(new URL(import.meta.url).pathname);
-
-/** @returns the glob patterns needed by tailwindcss to scan classes */
-export const contentGlobs = (): string[] => {
-  const path = contentPath();
-  return [
-    `${path}/index.mjs`,
-    `${path}/**/*.vue`,
-  ];
-};
 
 const deprefix = (name: string, prefix: string) => name.startsWith(prefix) ? name.slice(prefix.length) : undefined;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Tailwind CSS configuration support has been added to streamline style integration.
  
- **Refactor**
	- Internal configuration handling has been reorganized for consistency without altering existing setups.
  
- **Chore**
	- Package version updated to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->