### PR TITLE
feat(poupe-nuxt): drop @tailwindcss/forms as it interferes with styling

### DIFF
--- a/packages/poupe-nuxt/package.json
+++ b/packages/poupe-nuxt/package.json
@@ -69,7 +69,6 @@
     "@nuxt/icon": "^1.10.3",
     "@nuxtjs/color-mode": "^3.5.2",
     "@nuxtjs/tailwindcss": "^6.13.1",
-    "@tailwindcss/forms": "^0.5.10",
     "@types/stringify-object": "^4.0.5",
     "stringify-object": "^5.0.0",
     "tailwind-scrollbar": "^4.0.0"

--- a/packages/poupe-nuxt/src/tailwind.ts
+++ b/packages/poupe-nuxt/src/tailwind.ts
@@ -19,13 +19,11 @@ const getConfigContents = (
 
   return /* ts */`import { withMaterialColors, withPrintMode } from '@poupe/theme-builder/tailwind';
 
-import FormsPlugin from '@tailwindcss/forms';
 import ScrollbarPlugin from 'tailwind-scrollbar';
 
 const content = ${stringify(content)};
 
 const plugins = [
-  FormsPlugin,
   ScrollbarPlugin,
 ];
 

--- a/packages/poupe-vue/package.json
+++ b/packages/poupe-vue/package.json
@@ -39,7 +39,6 @@
     "clean": "rm -rf dist node_modules"
   },
   "dependencies": {
-    "@tailwindcss/forms": "^0.5.10",
     "@unhead/vue": "^1.11.18",
     "reka-ui": "1.0.0-alpha.9",
     "tailwind-merge": "^3.0.1",

--- a/packages/poupe-vue/src/config.ts
+++ b/packages/poupe-vue/src/config.ts
@@ -1,11 +1,9 @@
 import { dirname } from 'pathe';
 
-import FormsPlugin from '@tailwindcss/forms';
 import ScrollbarPlugin from 'tailwind-scrollbar';
 
 /** @returns array of required third-party tailwind plugins */
 export const tailwindPlugins = [
-  FormsPlugin,
   ScrollbarPlugin,
 ];
 

--- a/packages/poupe-vue/vite.config.ts
+++ b/packages/poupe-vue/vite.config.ts
@@ -34,7 +34,6 @@ export default defineConfig({
     rollupOptions: {
       external: [
         '@poupe/theme-builder',
-        '@tailwindcss/forms',
         'tailwind-variants',
         'tailwind-scrollbar',
         'tailwindcss',
@@ -43,7 +42,6 @@ export default defineConfig({
       output: {
         globals: {
           ['@poupe/theme-builder']: 'PoupeThemeBuilder',
-          ['@tailwindcss/forms']: 'TailwindcssForms',
           ['tailwind-variants']: 'TailwindVariants',
           ['tailwind-scrollbar']: 'TailwindScrollbar',
           tailwindcss: 'Tailwindcss',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@nuxtjs/tailwindcss':
         specifier: ^6.13.1
         version: 6.13.1(magicast@0.3.5)(rollup@4.34.0)
-      '@tailwindcss/forms':
-        specifier: ^0.5.10
-        version: 0.5.10(tailwindcss@3.4.17)
       '@types/stringify-object':
         specifier: ^4.0.5
         version: 4.0.5
@@ -112,9 +109,6 @@ importers:
 
   packages/poupe-vue:
     dependencies:
-      '@tailwindcss/forms':
-        specifier: ^0.5.10
-        version: 0.5.10(tailwindcss@3.4.17)
       '@unhead/vue':
         specifier: ^1.11.18
         version: 1.11.18(vue@3.5.13(typescript@5.6.3))
@@ -1465,11 +1459,6 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
-
-  '@tailwindcss/forms@0.5.10':
-    resolution: {integrity: sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1'
 
   '@tanstack/virtual-core@3.11.3':
     resolution: {integrity: sha512-v2mrNSnMwnPJtcVqNvV0c5roGCBqeogN8jDtgtuHCphdwBasOZ17x8UV8qpHUh+u0MLfX43c0uUHKje0s+Zb0w==}
@@ -3601,10 +3590,6 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-
-  mini-svg-data-uri@1.4.4:
-    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
-    hasBin: true
 
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
@@ -7170,11 +7155,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/forms@0.5.10(tailwindcss@3.4.17)':
-    dependencies:
-      mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.17
-
   '@tanstack/virtual-core@3.11.3': {}
 
   '@tanstack/vue-virtual@3.11.3(vue@3.5.13(typescript@5.6.3))':
@@ -9593,8 +9573,6 @@ snapshots:
   mimic-fn@4.0.0: {}
 
   min-indent@1.0.1: {}
-
-  mini-svg-data-uri@1.4.4: {}
 
   minimatch@3.0.8:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined styling by removing the previous form styling integration across both Nuxt and Vue packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->