### PR TITLE
feat(poupe-vue): add initial Input component

### DIFF
--- a/packages/poupe-vue/.vscode/settings.json
+++ b/packages/poupe-vue/.vscode/settings.json
@@ -10,6 +10,7 @@
     "Iconify",
     "Nuxt",
     "poupe",
+    "Reka",
     "unhead",
     "unplugin"
   ],

--- a/packages/poupe-vue/src/components/index.ts
+++ b/packages/poupe-vue/src/components/index.ts
@@ -1,6 +1,9 @@
 export { type ButtonProps, default as Button } from './button.vue';
 export { type CardProps, default as Card } from './card.vue';
 export { type IconProps, default as Icon } from './icon.vue';
+
+export * from './input';
+
 export { type PlaceholderProps, default as Placeholder } from './placeholder.vue';
 
 export * from './theme';

--- a/packages/poupe-vue/src/components/input/index.ts
+++ b/packages/poupe-vue/src/components/input/index.ts
@@ -1,0 +1,7 @@
+export {
+  type InputValue,
+  type InputType,
+  type InputWrapperProps as InputProps,
+} from './types';
+
+export { default as Input } from './wrapper.vue';

--- a/packages/poupe-vue/src/components/input/types.ts
+++ b/packages/poupe-vue/src/components/input/types.ts
@@ -14,7 +14,7 @@ import {
   containerVariants,
   roundedVariants,
 
-  px, py,
+  ps, pe, px, py,
 } from '../variants';
 
 export type InputValue = InputHTMLAttributes['value'];
@@ -25,7 +25,10 @@ export const padding = (n: number) => `${px[n]} ${py[n]}`;
 const paddingSlot = (n: number) => {
   return {
     [n]: {
+      start: padding(n),
       field: padding(n),
+      unit: `${ps[n + 1]} ${pe[n]} ${py[n]}`,
+      end: padding(n),
     },
   };
 };
@@ -34,7 +37,10 @@ export const inputWrapperVariants = tv({
   slots: {
     wrapper: 'flex flex-1 flex-nowrap rtl:flex-row-reverse overflow-hidden',
     field: 'flex-1',
+    start: '',
     input: 'w-full focus:outline-none',
+    unit: 'text-xs font-medium justify-end',
+    end: '',
   },
   variants: {
     surface: onSlot(['wrapper', 'input'], containerVariants),

--- a/packages/poupe-vue/src/components/input/types.ts
+++ b/packages/poupe-vue/src/components/input/types.ts
@@ -1,0 +1,70 @@
+import {
+  type InputHTMLAttributes,
+  type InputTypeHTMLAttribute,
+} from 'vue';
+
+import {
+  type VariantProps,
+  tv,
+
+  onSlot,
+
+  borderVariants,
+  borderInFocusVariants,
+  containerVariants,
+  roundedVariants,
+} from '../variants';
+
+export type InputValue = InputHTMLAttributes['value'];
+export type InputType = InputTypeHTMLAttribute;
+
+export const inputWrapperVariants = tv({
+  slots: {
+    wrapper: 'flex flex-1 flex-nowrap rtl:flex-row-reverse overflow-hidden',
+    field: 'flex-1 py-2 px-2',
+    input: 'w-full focus:outline-none',
+  },
+  variants: {
+    surface: onSlot(['wrapper', 'input'], containerVariants),
+    border: onSlot('wrapper', borderVariants),
+    outline: onSlot('wrapper', borderInFocusVariants),
+    rounded: onSlot('wrapper', {
+      ...roundedVariants,
+      full: `${roundedVariants.full} px-4`,
+    }),
+    expand: {
+      true: {
+        wrapper: 'w-full',
+      },
+    },
+  },
+  defaultVariants: {
+    surface: 'base',
+    border: 'outline',
+    outline: 'current',
+    rounded: 'full',
+    expand: false,
+  },
+});
+
+type InputWrapperVariantProps = VariantProps<typeof inputWrapperVariants>;
+
+export interface InputWrapperProps {
+  class?: string
+  id?: string
+  type?: InputType
+
+  modelValue?: InputValue
+  value?: never
+
+  surface?: InputWrapperVariantProps['surface']
+  border?: InputWrapperVariantProps['border']
+  outline?: InputWrapperVariantProps['outline']
+  rounded?: InputWrapperVariantProps['rounded']
+  expand?: InputWrapperVariantProps['expand']
+}
+
+export const defaultInputWrapperProps: InputWrapperProps = {
+  ...inputWrapperVariants.defaultVariants,
+  type: 'text',
+} as const;

--- a/packages/poupe-vue/src/components/input/types.ts
+++ b/packages/poupe-vue/src/components/input/types.ts
@@ -13,15 +13,27 @@ import {
   borderInFocusVariants,
   containerVariants,
   roundedVariants,
+
+  px, py,
 } from '../variants';
 
 export type InputValue = InputHTMLAttributes['value'];
 export type InputType = InputTypeHTMLAttribute;
 
+export const padding = (n: number) => `${px[n]} ${py[n]}`;
+
+const paddingSlot = (n: number) => {
+  return {
+    [n]: {
+      field: padding(n),
+    },
+  };
+};
+
 export const inputWrapperVariants = tv({
   slots: {
     wrapper: 'flex flex-1 flex-nowrap rtl:flex-row-reverse overflow-hidden',
-    field: 'flex-1 py-2 px-2',
+    field: 'flex-1',
     input: 'w-full focus:outline-none',
   },
   variants: {
@@ -32,6 +44,13 @@ export const inputWrapperVariants = tv({
       ...roundedVariants,
       full: `${roundedVariants.full} px-4`,
     }),
+    padding: {
+      ...paddingSlot(0),
+      ...paddingSlot(1),
+      ...paddingSlot(2),
+      ...paddingSlot(3),
+      ...paddingSlot(4),
+    },
     expand: {
       true: {
         wrapper: 'w-full',
@@ -43,6 +62,7 @@ export const inputWrapperVariants = tv({
     border: 'outline',
     outline: 'current',
     rounded: 'full',
+    padding: 2,
     expand: false,
   },
 });
@@ -61,6 +81,7 @@ export interface InputWrapperProps {
   border?: InputWrapperVariantProps['border']
   outline?: InputWrapperVariantProps['outline']
   rounded?: InputWrapperVariantProps['rounded']
+  padding?: InputWrapperVariantProps['padding']
   expand?: InputWrapperVariantProps['expand']
 }
 

--- a/packages/poupe-vue/src/components/input/types.ts
+++ b/packages/poupe-vue/src/components/input/types.ts
@@ -37,10 +37,10 @@ export const inputWrapperVariants = tv({
   slots: {
     wrapper: 'flex flex-1 flex-nowrap rtl:flex-row-reverse overflow-hidden',
     field: 'flex-1',
-    start: '',
+    start: 'flex items-center',
     input: 'w-full focus:outline-none',
     unit: 'text-xs font-medium justify-end',
-    end: '',
+    end: 'flex items-center',
   },
   variants: {
     surface: onSlot(['wrapper', 'input'], containerVariants),
@@ -82,6 +82,10 @@ export interface InputWrapperProps {
 
   modelValue?: InputValue
   value?: never
+
+  iconStart?: string
+  iconEnd?: string
+  unit?: string
 
   surface?: InputWrapperVariantProps['surface']
   border?: InputWrapperVariantProps['border']

--- a/packages/poupe-vue/src/components/input/wrapper.vue
+++ b/packages/poupe-vue/src/components/input/wrapper.vue
@@ -52,7 +52,11 @@ function usePasswordToggle() {
       :class="variants.start()"
       :padding="$props.padding"
     >
-      <div :class="variants.start()">
+      <div
+        :class="variants.start()"
+        role="presentation"
+        aria-hidden="true"
+      >
         <icon
           :icon="$props.iconStart"
         />
@@ -85,6 +89,8 @@ function usePasswordToggle() {
     >
       <div
         :class="variants.unit()"
+        role="note"
+        :aria-label="$props.unit"
         v-text="$props.unit"
       />
     </slot>
@@ -98,6 +104,8 @@ function usePasswordToggle() {
       <div
         v-if="$props.iconEnd !== undefined"
         :class="variants.end()"
+        role="presentation"
+        aria-hidden="true"
       >
         <icon
           :icon="$props.iconEnd"

--- a/packages/poupe-vue/src/components/input/wrapper.vue
+++ b/packages/poupe-vue/src/components/input/wrapper.vue
@@ -45,14 +45,19 @@ function usePasswordToggle() {
   <div
     :class="wrapperClasses"
   >
-    <!-- [[ start ][ field ][ end ]] -->
-    <slot name="start" />
+    <!-- [[ start ][ input ][ unit ][ end ]] -->
+    <slot
+      name="start"
+      :class="variants.start()"
+      :padding="$props.padding"
+    />
 
     <div :class="variants.field()">
       <slot
         :ref="forwardRef"
         name="field"
         :class="variants.input()"
+        :padding="$props.padding"
       >
         <input
           v-bind="$attrs"
@@ -65,11 +70,21 @@ function usePasswordToggle() {
       </slot>
     </div>
 
-    <slot name="end">
+    <slot
+      name="unit"
+      :class="variants.unit()"
+      :padding="$props.padding"
+    />
+
+    <slot
+      name="end"
+      :class="variants.end()"
+      :padding="$props.padding"
+    >
       <reka-toggle
         v-if="props.type === 'password'"
         v-model="showPassword"
-        class="p-2"
+        :class="variants.end()"
       >
         <icon :icon="passwordToggleIcon" />
       </reka-toggle>

--- a/packages/poupe-vue/src/components/input/wrapper.vue
+++ b/packages/poupe-vue/src/components/input/wrapper.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useForwardExpose } from 'reka-ui';
+import { twMerge } from '../variants';
+
+import {
+  type InputValue,
+  type InputWrapperProps,
+
+  defaultInputWrapperProps,
+  inputWrapperVariants,
+} from './types';
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const model = defineModel<InputValue>();
+const props = withDefaults(defineProps<InputWrapperProps>(), defaultInputWrapperProps);
+
+const variants = computed(() => inputWrapperVariants(props));
+const wrapperClasses = computed(() => twMerge(variants.value.wrapper(), props.class));
+
+const { forwardRef } = useForwardExpose();
+</script>
+
+<template>
+  <div
+    :class="wrapperClasses"
+  >
+    <!-- [[ start ][ field ][ end ]] -->
+    <slot name="start" />
+
+    <div :class="variants.field()">
+      <slot
+        :ref="forwardRef"
+        name="field"
+        :class="variants.input()"
+      >
+        <input
+          v-bind="$attrs"
+          :id="props.id"
+          :ref="forwardRef"
+          v-model="model"
+          :class="variants.input()"
+          :type="props.type"
+        >
+      </slot>
+    </div>
+
+    <slot name="end" />
+  </div>
+</template>

--- a/packages/poupe-vue/src/components/input/wrapper.vue
+++ b/packages/poupe-vue/src/components/input/wrapper.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useForwardExpose } from 'reka-ui';
+import { computed, ref } from 'vue';
+import { useForwardExpose, Toggle as RekaToggle } from 'reka-ui';
 import { twMerge } from '../variants';
+
+import { usePoupeIcons } from '@/composables/use-icons';
+
+import Icon from '../icon.vue';
 
 import {
   type InputValue,
@@ -22,6 +26,19 @@ const variants = computed(() => inputWrapperVariants(props));
 const wrapperClasses = computed(() => twMerge(variants.value.wrapper(), props.class));
 
 const { forwardRef } = useForwardExpose();
+
+const { poupe: icons } = usePoupeIcons().icons;
+const { showPassword, passwordToggleIcon, typeAttr } = usePasswordToggle();
+
+function usePasswordToggle() {
+  const showPassword = ref(false);
+
+  return {
+    showPassword,
+    passwordToggleIcon: computed(() => showPassword.value ? icons.hidePassword : icons.showPassword),
+    typeAttr: computed(() => showPassword.value ? 'text' : props.type),
+  };
+}
 </script>
 
 <template>
@@ -43,11 +60,19 @@ const { forwardRef } = useForwardExpose();
           :ref="forwardRef"
           v-model="model"
           :class="variants.input()"
-          :type="props.type"
+          :type="typeAttr"
         >
       </slot>
     </div>
 
-    <slot name="end" />
+    <slot name="end">
+      <reka-toggle
+        v-if="props.type === 'password'"
+        v-model="showPassword"
+        class="p-2"
+      >
+        <icon :icon="passwordToggleIcon" />
+      </reka-toggle>
+    </slot>
   </div>
 </template>

--- a/packages/poupe-vue/src/components/input/wrapper.vue
+++ b/packages/poupe-vue/src/components/input/wrapper.vue
@@ -47,10 +47,17 @@ function usePasswordToggle() {
   >
     <!-- [[ start ][ input ][ unit ][ end ]] -->
     <slot
+      v-if="$slots.start || $props.iconStart !== undefined"
       name="start"
       :class="variants.start()"
       :padding="$props.padding"
-    />
+    >
+      <div :class="variants.start()">
+        <icon
+          :icon="$props.iconStart"
+        />
+      </div>
+    </slot>
 
     <div :class="variants.field()">
       <slot
@@ -71,18 +78,34 @@ function usePasswordToggle() {
     </div>
 
     <slot
+      v-if="$slots.unit || $props.unit"
       name="unit"
       :class="variants.unit()"
       :padding="$props.padding"
-    />
+    >
+      <div
+        :class="variants.unit()"
+        v-text="$props.unit"
+      />
+    </slot>
 
     <slot
+      v-if="$slots.end || $props.iconEnd !== undefined || $props.type === 'password'"
       name="end"
       :class="variants.end()"
       :padding="$props.padding"
     >
+      <div
+        v-if="$props.iconEnd !== undefined"
+        :class="variants.end()"
+      >
+        <icon
+          :icon="$props.iconEnd"
+        />
+      </div>
+
       <reka-toggle
-        v-if="props.type === 'password'"
+        v-else-if="props.type === 'password'"
         v-model="showPassword"
         :class="variants.end()"
       >

--- a/packages/poupe-vue/src/components/variants/consts.ts
+++ b/packages/poupe-vue/src/components/variants/consts.ts
@@ -1,0 +1,27 @@
+export const ps: Record<number, string> = {
+    0: 'ps-0',
+    1: 'ps-1',
+    2: 'ps-2',
+    3: 'ps-3',
+    4: 'ps-4',
+    5: 'ps-5',
+    6: 'ps-6',
+  }, pe: Record<number, string> = {
+    0: 'pe-0',
+    1: 'pe-1',
+    2: 'pe-2',
+    3: 'pe-3',
+    4: 'pe-4',
+  }, px: Record<number, string> = {
+    0: 'px-0',
+    1: 'px-1',
+    2: 'px-2',
+    3: 'px-3',
+    4: 'px-4',
+  }, py: Record<number, string> = {
+    0: 'py-0',
+    1: 'py-1',
+    2: 'py-2',
+    3: 'py-3',
+    4: 'py-4',
+  };

--- a/packages/poupe-vue/src/components/variants/index.ts
+++ b/packages/poupe-vue/src/components/variants/index.ts
@@ -15,6 +15,16 @@ export const borderVariants = {
   outline: 'border-solid border border-outline',
 };
 
+export const borderInFocusVariants = {
+  none: 'focus-within:border-none',
+  current: 'focus-within:border-solid focus-within:border',
+  primary: 'focus-within:border-solid focus-within:border focus-within:border-primary',
+  secondary: 'focus-within:border-solid focus-within:border focus-within:border-secondary',
+  tertiary: 'focus-within:border-solid focus-within:border focus-within:border-tertiary',
+  error: 'focus-within:border-solid focus-within:border focus-within:border-error',
+  outline: 'focus-within:border-solid focus-within:border focus-within:border-outline',
+};
+
 export const roundedVariants = {
   full: 'rounded-full',
   none: 'rounded-none',

--- a/packages/poupe-vue/src/components/variants/index.ts
+++ b/packages/poupe-vue/src/components/variants/index.ts
@@ -1,6 +1,7 @@
 export { tv, type VariantProps } from 'tailwind-variants';
 export { twMerge } from 'tailwind-merge';
 
+export * from './consts';
 export * from './on-slot';
 export * from './on-variant';
 

--- a/packages/poupe-vue/src/composables/use-icons.ts
+++ b/packages/poupe-vue/src/composables/use-icons.ts
@@ -22,6 +22,9 @@ const blankIcon: IconValue = {
 const defaultIcons = {
   blankIcon,
   unknownIcon,
+  // input[type=password]
+  showPassword: 'heroicons:eye',
+  hidePassword: 'heroicons:eye-slash',
 };
 
 type IconNames = keyof typeof defaultIcons;

--- a/packages/poupe-vue/src/resolver.ts
+++ b/packages/poupe-vue/src/resolver.ts
@@ -4,6 +4,7 @@ export const components = [
   'Button',
   'Card',
   'Icon',
+  'Input',
   'Placeholder',
   'ThemeScheme',
 ] as const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a customizable input component that now supports password visibility toggling.
  - Expanded styling options with additional variant choices, ensuring enhanced visual consistency.
  - Updated the icon set to include dedicated icons for showing and hiding passwords.
  - Improved global component accessibility for easier integration of the input component into user interfaces.
  - Added new types and constants for better input handling and styling configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->