### PR TITLE
feat(poupe-vue): turn usePasswordToggle() into a  separate composable

### DIFF
--- a/packages/poupe-vue/src/components/input/wrapper.vue
+++ b/packages/poupe-vue/src/components/input/wrapper.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { useForwardExpose, Toggle as RekaToggle } from 'reka-ui';
 import { twMerge } from '../variants';
 
-import { usePoupeIcons } from '@/composables/use-icons';
+import { usePasswordToggle } from '@/composables/use-password';
 
 import Icon from '../icon.vue';
 
@@ -26,19 +26,7 @@ const variants = computed(() => inputWrapperVariants(props));
 const wrapperClasses = computed(() => twMerge(variants.value.wrapper(), props.class));
 
 const { forwardRef } = useForwardExpose();
-
-const { poupe: icons } = usePoupeIcons().icons;
-const { showPassword, passwordToggleIcon, typeAttr } = usePasswordToggle();
-
-function usePasswordToggle() {
-  const showPassword = ref(false);
-
-  return {
-    showPassword,
-    passwordToggleIcon: computed(() => showPassword.value ? icons.hidePassword : icons.showPassword),
-    typeAttr: computed(() => showPassword.value ? 'text' : props.type),
-  };
-}
+const { showPassword, passwordToggleIcon, typeAttr } = usePasswordToggle(props.type);
 </script>
 
 <template>

--- a/packages/poupe-vue/src/composables/use-password.ts
+++ b/packages/poupe-vue/src/composables/use-password.ts
@@ -1,0 +1,14 @@
+import { type MaybeRefOrGetter, computed, ref, toValue } from 'vue';
+import { usePoupeIcons } from './use-icons';
+
+export function usePasswordToggle(origType: MaybeRefOrGetter<string>) {
+  const { poupe: icons } = usePoupeIcons().icons;
+
+  const showPassword = ref(false);
+
+  return {
+    showPassword,
+    passwordToggleIcon: computed(() => (showPassword.value ? icons.hidePassword : icons.showPassword)),
+    typeAttr: computed(() => showPassword.value ? 'text' : toValue(origType)),
+  };
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the password visibility toggle, offering a smoother and more intuitive experience with dynamic icon updates when switching between masked and unmasked views.

- **Refactor**
  - Streamlined the underlying logic for managing password visibility, resulting in improved modularity and consistency in user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->