### PR TITLE
fix(poupe-vue): Icon: fix unknownIcon's color

### DIFF
--- a/packages/poupe-vue/src/composables/use-icons.ts
+++ b/packages/poupe-vue/src/composables/use-icons.ts
@@ -15,7 +15,7 @@ const blankIcon: IconValue = {
     width: 24,
     height: 24,
   }, unknownIcon: IconValue = {
-    body: '<text y=".9em" font-size="90">�</text>',
+    body: '<text y=".9em" font-size="90" fill="currentColor">�</text>',
     width: 100,
     height: 100,
   };


### PR DESCRIPTION
to match the current text color

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated icon rendering to inherit the current text color, ensuring a more consistent visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->