### PR TITLE
feat(poupe-vue): Input: use ring for the outline property

### DIFF
--- a/packages/poupe-vue/src/components/variants/index.ts
+++ b/packages/poupe-vue/src/components/variants/index.ts
@@ -16,13 +16,13 @@ export const borderVariants = {
 };
 
 export const borderInFocusVariants = {
-  none: 'focus-within:border-none',
-  current: 'focus-within:border-solid focus-within:border',
-  primary: 'focus-within:border-solid focus-within:border focus-within:border-primary',
-  secondary: 'focus-within:border-solid focus-within:border focus-within:border-secondary',
-  tertiary: 'focus-within:border-solid focus-within:border focus-within:border-tertiary',
-  error: 'focus-within:border-solid focus-within:border focus-within:border-error',
-  outline: 'focus-within:border-solid focus-within:border focus-within:border-outline',
+  none: 'focus-within:ring-transparent',
+  current: 'focus-within:ring-solid focus-within:ring-2',
+  primary: 'focus-within:ring-solid focus-within:ring-2 focus-within:ring-primary',
+  secondary: 'focus-within:ring-solid focus-within:ring-2 focus-within:ring-secondary',
+  tertiary: 'focus-within:ring-solid focus-within:ring-2 focus-within:ring-tertiary',
+  error: 'focus-within:ring-solid focus-within:ring-2 focus-within:ring-error',
+  outline: 'focus-within:ring-solid focus-within:ring-2 focus-within:ring-outline',
 };
 
 export const roundedVariants = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Revised focus visual indicators: the previous border highlights have been replaced with ring-based outlines featuring updated thickness and color variations. This change provides a more modern, accessible, and distinct focus state for interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->