### PR TITLE
feat(poupe-vue): Button: change default shadow to none

### DIFF
--- a/packages/poupe-vue/src/components/button.vue
+++ b/packages/poupe-vue/src/components/button.vue
@@ -54,7 +54,7 @@ const button = tv({
   defaultVariants: {
     border: 'none',
     rounded: 'md',
-    shadow: 'md',
+    shadow: 'none',
     surface: 'base',
     size: 'base',
     expand: false,

--- a/packages/poupe-vue/src/components/button.vue
+++ b/packages/poupe-vue/src/components/button.vue
@@ -14,16 +14,6 @@ import {
   containerVariants,
 } from './variants';
 
-const defaultVariantProps = {
-  border: 'none' as const,
-  rounded: 'md' as const,
-  shadow: 'md' as const,
-  surface: 'base' as const,
-  size: 'base' as const,
-  expand: false,
-  disabled: false,
-};
-
 const sizeVariantProps = {
   xs: 'text-xs font-light m-1 p-1',
   sm: 'text-sm m-2 font-light px-2 py-1',
@@ -45,6 +35,7 @@ const button = tv({
     rounded: onSlot('wrapper', roundedVariants),
     shadow: onSlot('wrapper', shadowVariants),
     size: onSlot('wrapper', sizeVariantProps),
+
     disabled: {
       true: {
         wrapper: 'cursor-not-allowed',
@@ -60,7 +51,15 @@ const button = tv({
       },
     },
   },
-  defaultVariants: defaultVariantProps,
+  defaultVariants: {
+    border: 'none',
+    rounded: 'md',
+    shadow: 'md',
+    surface: 'base',
+    size: 'base',
+    expand: false,
+    disabled: false,
+  },
 });
 
 type ButtonVariantProps = VariantProps<typeof button>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the button’s default appearance by removing the shadow effect, resulting in a cleaner, flatter look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->