### PR TITLE
feat(poupe-vue): improve resolver tests

### DIFF
--- a/packages/poupe-vue/src/__tests__/resolver.spec.ts
+++ b/packages/poupe-vue/src/__tests__/resolver.spec.ts
@@ -3,7 +3,7 @@ import { components, createResolver } from '../resolver';
 import * as Poupe from '../index';
 
 it('should export only the components', () => {
-  expect(Object.keys(Poupe)).toEqual(components);
+  expect(new Set(Object.keys(Poupe))).toEqual(new Set(components));
 });
 
 it('should resolve component with default prefix', () => {


### PR DESCRIPTION
comparing components list as sets as export order isn't warranted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by updating assertions to compare sets instead of arrays, ensuring tests are not affected by the order of exported keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->