### PR TITLE
feat(poupe-tailwindcss): implement initial theme plugin

### DIFF
--- a/packages/@poupe-nuxt/package.json
+++ b/packages/@poupe-nuxt/package.json
@@ -57,6 +57,7 @@
     "eslint": "^9.26.0",
     "npm-run-all2": "^8.0.1",
     "nuxt": "^3.17.2",
+    "publint": "^0.3.12",
     "typescript": "^5.8.3",
     "unbuild": "3.5.0",
     "vite": "^6.3.5",

--- a/packages/@poupe-nuxt/package.json
+++ b/packages/@poupe-nuxt/package.json
@@ -69,7 +69,8 @@
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@types/stringify-object": "^4.0.5",
     "stringify-object": "^5.0.0",
-    "tailwind-scrollbar": "^4.0.2"
+    "tailwind-scrollbar": "^4.0.2",
+    "tailwindcss": "^3.4.17"
   },
   "peerDependencies": {
     "@poupe/theme-builder": "^0.6.8",

--- a/packages/@poupe-tailwindcss/build.config.ts
+++ b/packages/@poupe-tailwindcss/build.config.ts
@@ -1,0 +1,5 @@
+import { defineBuildConfig } from 'unbuild';
+
+export default defineBuildConfig({
+  sourcemap: true,
+});

--- a/packages/@poupe-tailwindcss/package.json
+++ b/packages/@poupe-tailwindcss/package.json
@@ -42,6 +42,7 @@
     "@poupe/eslint-config": "^0.6.3",
     "@poupe/theme-builder": "workspace:^",
     "eslint": "^9.25.1",
+    "publint": "^0.3.12",
     "typescript": "^5.8.3",
     "unbuild": "3.5.0",
     "vitest": "^3.1.2",

--- a/packages/@poupe-tailwindcss/package.json
+++ b/packages/@poupe-tailwindcss/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@poupe/tailwindcss",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "tailwindcss v4 plugin to use poupe theme builder",
+  "author": "Alejandro Mery <amery@apptly.co>",
+  "license": "MIT",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/poupe-ui/poupe.git",
+    "directory": "packages/@poupe-tailwindcss"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
+    "./theme": {
+      "types": "./dist/theme.d.ts",
+      "import": "./dist/theme.mjs"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "prepack": "run-s lint type-check test build publint",
+    "dev:prepare": "unbuild --stub",
+    "type-check": "tsc --noEmit",
+    "lint": "env DEBUG=eslint:eslint eslint --fix .",
+    "publint": "pnpx publint",
+    "build": "unbuild",
+    "test": "vitest run",
+    "dev": "vitest watch",
+    "clean": "rm -rf dist node_modules"
+  },
+  "devDependencies": {
+    "@poupe/eslint-config": "^0.6.3",
+    "eslint": "^9.25.1",
+    "typescript": "^5.8.3",
+    "unbuild": "3.5.0",
+    "vitest": "^3.1.2",
+    "vue-tsc": "^2.2.10"
+  },
+  "dependencies": {
+    "tailwindcss": "^4.1.5"
+  }
+}

--- a/packages/@poupe-tailwindcss/package.json
+++ b/packages/@poupe-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/tailwindcss",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "type": "module",
   "description": "tailwindcss v4 plugin to use poupe theme builder",
   "author": "Alejandro Mery <amery@apptly.co>",
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@poupe/eslint-config": "^0.6.3",
+    "@poupe/theme-builder": "workspace:^",
     "eslint": "^9.25.1",
     "typescript": "^5.8.3",
     "unbuild": "3.5.0",
@@ -48,5 +49,8 @@
   },
   "dependencies": {
     "tailwindcss": "^4.1.5"
+  },
+  "peerDependencies": {
+    "@poupe/theme-builder": "^0.6.8"
   }
 }

--- a/packages/@poupe-tailwindcss/src/flat/index.ts
+++ b/packages/@poupe-tailwindcss/src/flat/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin';

--- a/packages/@poupe-tailwindcss/src/flat/plugin.test.ts
+++ b/packages/@poupe-tailwindcss/src/flat/plugin.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('dummy', () => {
+  expect(true).eq(true);
+});

--- a/packages/@poupe-tailwindcss/src/flat/plugin.ts
+++ b/packages/@poupe-tailwindcss/src/flat/plugin.ts
@@ -1,0 +1,30 @@
+import {
+  type PluginAPI,
+  type PluginWithOptions,
+  pluginWithOptions,
+} from '../utils/plugin';
+
+export type FlatOptions = unknown & {};
+
+/** poupe plugin for tailwindcss v4 embedded in the default CSS */
+export const flatPlugin: PluginWithOptions<FlatOptions> = pluginWithOptions(
+  pluginFunction,
+  configFunction,
+  defaultsFunction,
+);
+
+function pluginFunction(api: PluginAPI, options: FlatOptions): void {
+  console.log(`${logPrefix}:pluginFunction`, options, api);
+};
+
+function configFunction(options: FlatOptions): FlatOptions {
+  console.log(`${logPrefix}:configFunction`, options);
+  return options;
+}
+
+function defaultsFunction(options: FlatOptions = {}): FlatOptions {
+  console.log(`${logPrefix}:defaultsFunction`, options);
+  return options;
+}
+
+const logPrefix = '@poupe/tailwindcss/flat';

--- a/packages/@poupe-tailwindcss/src/index.ts
+++ b/packages/@poupe-tailwindcss/src/index.ts
@@ -1,0 +1,11 @@
+export {
+  type FlatOptions,
+
+  flatPlugin as default,
+} from './flat/index';
+
+export {
+  type ThemeOptions,
+
+  themePlugin as createPlugin,
+} from './theme/index';

--- a/packages/@poupe-tailwindcss/src/theme.ts
+++ b/packages/@poupe-tailwindcss/src/theme.ts
@@ -1,0 +1,1 @@
+export * from './theme/index';

--- a/packages/@poupe-tailwindcss/src/theme/config.ts
+++ b/packages/@poupe-tailwindcss/src/theme/config.ts
@@ -1,0 +1,89 @@
+import {
+  type Theme,
+} from './types';
+
+import {
+  type Config,
+  unsafeKeys,
+  debugLog,
+} from './utils';
+
+import tailwindColors from 'tailwindcss/colors';
+
+export {
+  type Config,
+} from './utils';
+
+/**
+ * Generates a Tailwind CSS colors configuration based on a theme definition.
+ *
+ * @param theme - The theme configuration containing color definitions and options
+ * @returns A partial Tailwind CSS configuration with processed colors
+ *
+ * @remarks
+ * This function transforms creates Tailwind CSS colors using
+ * the theme's CSS variables.
+ * It includes definitions for inherit, current, transparent, white and black
+ * in addition to the dynamically generated color variations.
+ */
+export function makeConfig(
+  theme: Theme,
+  persistentColors: Record<string, string> = defaultPersistentColors,
+): Partial<Config> {
+  debugLog(theme.options.debug, 'makeConfig', theme);
+
+  type ColorKey = keyof typeof theme.colors | keyof typeof persistentColors;
+
+  type ColorValue = string | Record<'DEFAULT' | number, string>;
+
+  const { extendColors = false } = theme.options;
+
+  const colors: Record<ColorKey, ColorValue> = {
+    ...(extendColors ? persistentColors : {}),
+  };
+
+  for (const key of theme.keys) {
+    const c = theme.colors[key];
+    colors[key] = makeConfigColor(key, c.value, c.shades);
+  }
+
+  if (extendColors) {
+    return {
+      theme: {
+        extend: {
+          colors,
+        },
+      },
+    };
+  }
+
+  return {
+    theme: {
+      colors,
+    },
+  };
+}
+
+export function makeConfigColor<N extends number>(key: string, value: string, shades?: Record<N, string>): (string | Record<'DEFAULT' | N, string>) {
+  if (shades) {
+    const out = {
+      DEFAULT: `var(${value})`,
+    } as Record<'DEFAULT' | N, string>;
+
+    for (const shade of unsafeKeys(shades)) {
+      out[shade] = `var(${shades[shade]})`;
+    }
+
+    return out;
+  }
+
+  return `var(${value})`;
+}
+
+export const defaultPersistentColors = {
+  inherit: tailwindColors.inherit,
+  current: tailwindColors.current,
+  transparent: tailwindColors.transparent,
+  black: tailwindColors.black,
+  white: tailwindColors.white,
+};

--- a/packages/@poupe-tailwindcss/src/theme/index.ts
+++ b/packages/@poupe-tailwindcss/src/theme/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin';

--- a/packages/@poupe-tailwindcss/src/theme/index.ts
+++ b/packages/@poupe-tailwindcss/src/theme/index.ts
@@ -1,1 +1,23 @@
-export * from './plugin';
+export * from './types';
+
+export {
+  withDefaultThemeOptions,
+} from './options';
+
+export {
+  themePlugin,
+  themePluginFunction,
+  themeConfigFunction,
+  makeThemeFromPartialOptions,
+} from './plugin';
+
+export {
+  makeTheme,
+  makeThemeBases,
+  makeThemeComponents,
+} from './theme';
+
+export {
+  type Config,
+  makeConfig,
+} from './config';

--- a/packages/@poupe-tailwindcss/src/theme/options.ts
+++ b/packages/@poupe-tailwindcss/src/theme/options.ts
@@ -1,0 +1,119 @@
+import {
+  type ThemeOptions,
+  type ThemeColors,
+  type ThemeColorOptions,
+
+  defaultPrimaryColor,
+  defaultThemeScheme,
+  defaultThemeContrast,
+  defaultThemePrefix,
+  defaultThemeDarkSuffix,
+  defaultThemeLightSuffix,
+} from './types';
+
+import {
+  kebabCase,
+  getColor,
+  unsafeKeys,
+} from './utils';
+
+import {
+  type Shades,
+  getShades,
+  defaultShades,
+} from './shades';
+
+export {
+  type ThemeOptions,
+} from './types';
+
+export function withDefaultThemeOptions<K extends string = string>(options: Partial<ThemeOptions<K>> = {}): ThemeOptions<K> {
+  const { shades, ok } = getShades(options.shades, defaultShades);
+  if (!ok) {
+    throw new Error('Invalid shades configuration');
+  }
+
+  const colors = withDefaultThemeColorOptions(
+    { ...(options.colors ?? { primary: {} }) } as ThemeColors<K>,
+    shades,
+  );
+
+  return {
+    debug: options.debug ?? false,
+    themePrefix: options.themePrefix ?? defaultThemePrefix,
+    omitTheme: options.omitTheme ?? false,
+    extendColors: options.extendColors ?? false,
+
+    darkSuffix: options.darkSuffix ?? defaultThemeDarkSuffix,
+    lightSuffix: options.lightSuffix ?? defaultThemeLightSuffix,
+    scheme: options.scheme ?? defaultThemeScheme,
+    contrast: options.contrast ?? defaultThemeContrast,
+
+    shades,
+    colors,
+  };
+}
+
+export function withDefaultThemeColorOptions<K extends string = string>(
+  colors: ThemeColors<K>,
+  defaultShades: Shades,
+): ThemeColors<K> {
+  const out: Record<string, ThemeColorOptions> = {};
+
+  for (const key of unsafeKeys(colors)) {
+    const name = kebabCase(key);
+    if (name in out) {
+      throw new Error(`Duplicate normalized color name: ${key}/${name}`);
+    }
+
+    const color = flattenColorOptions(colors[key]);
+    out[name] = cookColor(name, color, defaultShades);
+  }
+
+  return out as ThemeColors<K>;
+}
+
+/**
+ * Processes and validates color configuration for a theme color.
+ *
+ * @param name - The name of the color (e.g., 'primary', 'secondary')
+ * @param options - Color configuration options
+ * @param defaultShades - Default shades to use if not specified
+ * @returns Processed and validated theme color options
+ * @throws an Error if color value or shades are invalid.
+ */
+const cookColor = (name: string, options: ThemeColorOptions | undefined, defaultShades: Shades): ThemeColorOptions => {
+  // primary can't be harmonized, for all others it defaults to true.
+  const { color: value, ok: colorOK } = getColor(name, options?.value);
+  if (!colorOK) {
+    throw new Error(`Invalid color value for ${name}: ${options?.value}`);
+  }
+
+  let shades: Shades = false;
+  if (options?.shades !== false) {
+    const { shades: colorShades, ok: shadesOK } = getShades(options?.shades, defaultShades);
+    if (!shadesOK) {
+      throw new Error(`Invalid shades for ${name}: ${options?.shades}`);
+    }
+
+    shades = colorShades;
+  }
+
+  return {
+    value: value ?? (name === 'primary' ? defaultPrimaryColor : undefined),
+    ...(name === 'primary' ? {} : { harmonized: options?.harmonized ?? true }),
+    shades,
+  };
+};
+
+export function flattenColorOptions(color?: boolean | string | ThemeColorOptions): ThemeColorOptions | undefined {
+  if (color === undefined) {
+    return undefined;
+  } else if (typeof color === 'boolean') {
+    return { harmonized: color };
+  } else if (typeof color === 'string') {
+    return { value: color };
+  } else {
+    return color;
+  }
+}

--- a/packages/@poupe-tailwindcss/src/theme/plugin.test.ts
+++ b/packages/@poupe-tailwindcss/src/theme/plugin.test.ts
@@ -1,5 +1,29 @@
-import { expect, test } from 'vitest';
+import { describe, it, expect } from 'vitest';
+import { themePlugin } from './plugin';
 
-test('dummy', () => {
-  expect(true).eq(true);
+describe('themePlugin', () => {
+  it('should implement PluginWithOptions interface', () => {
+    expect(themePlugin).toBeDefined();
+    expect(typeof themePlugin).toBe('function');
+
+    // Check for expected method signatures typical of Tailwind CSS v4 plugin
+    expect(themePlugin).toHaveProperty('__isOptionsFunction', true);
+
+    // Verify the plugin can be called with options
+    const mockOptions = {};
+    const pluginResult = themePlugin(mockOptions);
+
+    expect(pluginResult).toBeTruthy();
+    expect(typeof pluginResult).toBe('object');
+
+    // check for the plugin handler
+    expect(pluginResult).toHaveProperty('handler');
+    expect(typeof pluginResult.handler).toBe('function');
+
+    // check for the theme config
+    expect(pluginResult).toHaveProperty('config');
+    expect(typeof pluginResult.config).toBe('object');
+    expect(pluginResult.config).toHaveProperty('theme');
+    expect(typeof pluginResult.config?.theme).toBe('object');
+  });
 });

--- a/packages/@poupe-tailwindcss/src/theme/plugin.test.ts
+++ b/packages/@poupe-tailwindcss/src/theme/plugin.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('dummy', () => {
+  expect(true).eq(true);
+});

--- a/packages/@poupe-tailwindcss/src/theme/plugin.ts
+++ b/packages/@poupe-tailwindcss/src/theme/plugin.ts
@@ -1,0 +1,30 @@
+import {
+  type PluginAPI,
+  type PluginWithOptions,
+  pluginWithPartialOptions,
+} from '../utils/plugin';
+
+export type ThemeOptions = unknown & {};
+
+/** poupe plugin for tailwindcss v4 for config use */
+export const themePlugin: PluginWithOptions<ThemeOptions> = pluginWithPartialOptions(
+  pluginFunction,
+  configFunction,
+  defaultsFunction,
+);
+
+function pluginFunction(api: PluginAPI, options: ThemeOptions): void {
+  console.log(`${logPrefix}:pluginFunction`, options, api);
+};
+
+function configFunction(options: ThemeOptions): ThemeOptions {
+  console.log(`${logPrefix}:configFunction`, options);
+  return options;
+}
+
+function defaultsFunction(options: Partial<ThemeOptions> = {}): ThemeOptions {
+  console.log(`${logPrefix}:defaultsFunction`, options);
+  return options;
+}
+
+const logPrefix = '@poupe/tailwindcss';

--- a/packages/@poupe-tailwindcss/src/theme/shades.ts
+++ b/packages/@poupe-tailwindcss/src/theme/shades.ts
@@ -1,0 +1,88 @@
+import {
+  type Color,
+  Hct,
+  hct,
+  splitHct,
+} from '../utils/builder';
+
+/** Represents the possible types for color shades: an array of numbers or false */
+export type Shades = number[] | false;
+
+/** Default color shades used when no custom shades are specified, representing a standard range of color intensity from lightest (50) to darkest (950) */
+export const defaultShades = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950];
+
+/**
+ * Processes and validates color shades, with optional append mode and default handling.
+ *
+ * @param shades - An optional array of shade values, boolean, or undefined
+ * @param defaults - Default shade values to use, defaults to `defaultShades`
+ * @returns An object containing processed shades and a validation status
+ *
+ * - If `shades` is `false`, returns `false` shades
+ * - If `shades` is `true` or `undefined`, returns default shades
+ * - Supports negative values to append to default shades
+ * - Validates each shade value
+ * - Returns sorted unique shade values
+ */
+export function getShades(shades?: number[] | boolean | undefined, defaults: number[] | false = defaultShades): { shades: Shades; ok: boolean } {
+  if (shades === false) {
+    return { shades: false, ok: true };
+  } else if (shades === true || shades === undefined) {
+    return { shades: defaults, ok: true };
+  } else if (!Array.isArray(shades)) {
+    return { shades: false, ok: false };
+  }
+
+  let appendMode = false;
+  const out = new Set<number>();
+
+  for (let shade of shades) {
+    if (shade < 0) {
+      appendMode = true;
+      shade = -shade;
+    }
+
+    if (!validShade(shade)) {
+      return { shades: false, ok: false };
+    }
+
+    out.add(shade);
+  }
+
+  if (out.size === 0) {
+    return { shades: false, ok: false };
+  }
+
+  if (appendMode && defaults) {
+    for (const shade of defaults) {
+      out.add(shade);
+    }
+  }
+
+  return {
+    shades: [...out].sort((a, b) => a - b),
+    ok: true,
+  };
+}
+
+/** @returns true if the given number is a valid shade value */
+export function validShade(n: number): boolean {
+  return n > 0 && n < 1000 && Math.round(n) == n;
+}
+
+export function makeShades(color: Color, shades: false): undefined;
+export function makeShades<K extends number>(color: Color, shades: K[]): Record<K, Hct>;
+export function makeShades<K extends number>(color: Color, shades: K[] | false): Record<K, Hct> | undefined;
+export function makeShades<K extends number>(color: Color, shades: K[] | false): Record<K, Hct> | undefined {
+  if (!shades) {
+    return undefined;
+  }
+
+  const { h, c } = splitHct(hct(color));
+
+  return Object.fromEntries(shades.map((shade) => {
+    const tone = (1000 - shade) / 10;
+
+    return [shade, Hct.from(h, c, tone)];
+  })) as Record<K, Hct>;
+}

--- a/packages/@poupe-tailwindcss/src/theme/theme.ts
+++ b/packages/@poupe-tailwindcss/src/theme/theme.ts
@@ -1,0 +1,211 @@
+import {
+  type Theme,
+  type ThemeOptions,
+  type ThemeColorConfig,
+  defaultThemePrefix,
+} from './types';
+
+import {
+  type DarkModeStrategy,
+  unsafeKeys,
+  getDarkMode,
+  hslString,
+  debugLog,
+} from './utils';
+
+import {
+  flattenColorOptions,
+} from './options';
+
+import {
+  type CSSRuleObject,
+  type ColorMap,
+  type ThemeColors as ThemeBuilderColors,
+  Hct,
+  assembleCSSColors,
+  makeTheme as makeThemeColors,
+  makeThemeKeys,
+} from '@poupe/theme-builder';
+
+import {
+  type Shades,
+  getShades,
+  makeShades,
+} from './shades';
+
+export {
+  type Theme,
+} from './types';
+
+/**
+ * Creates a theme configuration based on the provided theme options.
+ *
+ * @param options - Theme configuration options
+ * @returns A fully configured theme object with color palettes for dark and light modes
+ *
+ * @remarks
+ * This function supports two theme generation modes:
+ * - When `omitTheme` is true, it generates a theme with minimal configuration
+ * - When `omitTheme` is false (default), it generates a full theme with dark and light color palettes
+ */
+export function makeTheme<K extends string>(options: ThemeOptions<K>) {
+  debugLog(options.debug, 'makeTheme', options);
+
+  const $colors = options.colors as ThemeBuilderColors<K>;
+  const { omitTheme = false } = options;
+
+  if (omitTheme) {
+    const { keys, paletteKeys } = makeThemeKeys($colors);
+
+    return newTheme<K, typeof paletteKeys[number], typeof keys[number]>(options, paletteKeys, keys);
+  }
+
+  const {
+    dark,
+    light,
+    darkPalette,
+  } = makeThemeColors($colors, options.scheme, options.contrast);
+
+  const keys = unsafeKeys(dark);
+  const paletteKeys = unsafeKeys(darkPalette);
+
+  return newTheme<K, typeof paletteKeys[number], typeof keys[number]>(options, paletteKeys, keys, dark, light);
+}
+
+function newTheme<
+  K0 extends string,
+  K1 extends string,
+  K2 extends string,
+>(
+  options: ThemeOptions<K0>,
+  paletteKeys: K1[],
+  keys: K2[],
+  dark?: Record<K2, Hct>,
+  light?: Record<K2, Hct>,
+): Theme {
+  const darkColors: ColorMap<string> | undefined = dark ? {} as ColorMap<string> : undefined;
+  const lightColors: ColorMap<string> | undefined = light ? {} as ColorMap<string> : undefined;
+  const colors: Record<K2, ThemeColorConfig> = {} as Record<K2, ThemeColorConfig>;
+
+  const { themePrefix = defaultThemePrefix } = options;
+  const defaultShades = options.shades;
+
+  // iterate over palette colors that might have custom shades
+  for (const k0 of unsafeKeys(options.colors)) {
+    const color = flattenColorOptions(options.colors[k0]);
+    const { shades } = getShades(color?.shades, defaultShades);
+
+    setColor(k0 as K2, themePrefix, shades, colors, darkColors, lightColors, dark, light);
+  }
+
+  // rest of the palette keys take the default shades
+  for (const key of paletteKeys as unknown[] as K2[]) {
+    if (key in colors) continue;
+
+    setColor(key, themePrefix, defaultShades, colors, darkColors, lightColors, dark, light);
+  }
+
+  // and the rest have no shades
+  for (const key of keys) {
+    if (key in colors) continue;
+
+    setColor(key, themePrefix, false, colors, darkColors, lightColors, dark, light);
+  }
+
+  return {
+    options,
+    keys,
+    paletteKeys,
+    dark: darkColors,
+    light: lightColors,
+    colors,
+  };
+}
+
+function setColor<K extends string>(
+  key: K,
+  prefix: string,
+  shades: Shades,
+  colors: Record<K, ThemeColorConfig>,
+  darkColors: ColorMap<string> | undefined,
+  lightColors: ColorMap<string> | undefined,
+  dark: Record<K, Hct> | undefined,
+  light: Record<K, Hct> | undefined,
+) {
+  if (dark && darkColors) {
+    for (const [k, v] of newThemeColorHct(key, dark[key], shades)) {
+      darkColors[k] = v;
+    }
+  }
+
+  if (light && lightColors) {
+    for (const [k, v] of newThemeColorHct(key, light[key], shades)) {
+      lightColors[k] = v;
+    }
+  }
+
+  colors[key] = newThemeColorConfig(key, shades, prefix);
+}
+
+function newThemeColorHct(key: string, value: Hct, shades: Shades): [string, Hct][] {
+  const out: [string, Hct][] = [
+    [key, value],
+  ];
+
+  if (shades) {
+    const shadesMap = makeShades(value, shades);
+    for (const shade of shades) {
+      out.push([`${key}-${shade}`, shadesMap[shade]]);
+    }
+  }
+
+  return out;
+}
+
+function newThemeColorConfig(key: string, shades: Shades, prefix: string): ThemeColorConfig {
+  const base = `--${prefix}${key}`;
+
+  if (!shades) {
+    return {
+      value: base,
+    };
+  }
+
+  return {
+    value: base,
+    shades: Object.fromEntries(shades.map(shade => [shade, `${base}-${shade}`])),
+  };
+}
+
+export function makeThemeBases(
+  theme: Readonly<Theme>,
+  darkMode: DarkModeStrategy = 'class',
+): CSSRuleObject[] {
+  debugLog(theme.options.debug, 'makeThemeBases', darkMode, theme);
+
+  const bases: CSSRuleObject[] = [];
+
+  if (theme.dark && theme.light) {
+    const { styles } = assembleCSSColors<string>(
+      theme.dark,
+      theme.light as typeof theme.dark,
+      {
+        darkMode: getDarkMode(darkMode),
+        lightMode: false,
+        prefix: theme.options.themePrefix,
+        darkSuffix: theme.options.darkSuffix,
+        lightSuffix: theme.options.lightSuffix,
+        stringify: hslString,
+      },
+    );
+    bases.push(...styles);
+  }
+
+  return bases;
+}
+
+export function makeThemeComponents(theme: Readonly<Theme>): Record<string, CSSRuleObject>[] {
+  debugLog(theme.options.debug, 'makeThemeComponents', theme);
+  // TODO: implement
+  return [];
+}

--- a/packages/@poupe-tailwindcss/src/theme/types.ts
+++ b/packages/@poupe-tailwindcss/src/theme/types.ts
@@ -1,0 +1,119 @@
+import {
+  type ColorMap,
+  type StandardPaletteKey,
+  type StandardDynamicSchemeKey,
+} from '@poupe/theme-builder';
+
+import {
+  type KebabCase,
+} from '../utils/builder';
+
+import {
+  type Shades,
+} from './shades';
+
+export {
+  type Color,
+  type StandardPaletteKey,
+  type StandardDynamicSchemeKey,
+} from '@poupe/theme-builder';
+
+export {
+  type KebabCase,
+} from '@poupe/theme-builder/utils';
+
+export {
+  type Shades,
+  defaultShades,
+} from './shades';
+
+export type Theme = {
+  readonly options: ThemeOptions
+  readonly paletteKeys: string[]
+  readonly keys: string[]
+
+  readonly dark: ColorMap<string> | undefined
+  readonly light: ColorMap<string> | undefined
+  readonly colors: Record<string, ThemeColorConfig>
+};
+
+export type ThemeColorConfig = {
+  value: string
+  shades?: Record<number, string>
+};
+
+/**
+ * Configuration options for defining a theme with customizable color schemes and styling.
+ * @typeParam K - A generic type parameter representing additional color keys.
+ **/
+export type ThemeOptions<K extends string = string> = {
+  /** Enable debug mode for theme generation. @defaultValue `false` */
+  debug?: boolean
+
+  /** Prefix for theme-related class names, defaults to 'md-'.  @defaultValue `'md-'` */
+  themePrefix: string
+
+  /** Flag to omit theme generation, @defaultValue `false` */
+  omitTheme: boolean
+
+  /** Flag to extend existing color palette, @defaultValue `false` */
+  extendColors: boolean
+
+  /** Dynamic color scheme type, @defaultValue `'content'` */
+  scheme: StandardDynamicSchemeKey
+
+  /** Theme contrast level, @defaultValue `0` */
+  contrast: number
+
+  /** Suffix for dark theme variants, @defaultValue `''` */
+  darkSuffix: string
+
+  /** Suffix for light theme variants, @defaultValue `''` */
+  lightSuffix: string
+
+  /** Color shade values used in theme generation,
+   * @defaultValue `[50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]`
+   **/
+  shades: Shades
+
+  /** Color configuration for the theme. */
+  colors: ThemeColors<K>
+};
+
+/**
+ * Defines the color configuration for a theme, including primary and optional additional colors.
+ * @typeParam K - A generic type parameter representing custom color keys.
+ * @remarks
+ * This type allows defining:
+ * - A required primary color configuration
+ * - Optional standard palette colors (excluding primary)
+ * - Custom color keys transformed to kebab-case
+ */
+export type ThemeColors<K extends string> = {
+  primary: string | ThemeColorOptions
+} & {
+  [name in Exclude<StandardPaletteKey, 'primary'>]?: string | ThemeColorOptions
+} & {
+  [name in KebabCase<K>]: boolean | string | ThemeColorOptions
+};
+
+/**
+ * Defines the options for a color configuration within a theme.
+ * @remarks
+ * This type allows defining:
+ * - The color value, either a string or an object with default and shade values.
+ * - Whether the color should be harmonized.
+ * - The shades associated with the color.
+ */
+export type ThemeColorOptions = {
+  value?: string
+  harmonized?: boolean
+  shades?: Shades | true /** @defaultValue `[50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950]` */
+};
+
+export const defaultPrimaryColor = '#74bef5'; // blue from Tailwind CSS's logo
+export const defaultThemePrefix = 'md-';
+export const defaultThemeDarkSuffix = '';
+export const defaultThemeLightSuffix = '';
+export const defaultThemeContrast = 0;
+export const defaultThemeScheme: StandardDynamicSchemeKey = 'content';

--- a/packages/@poupe-tailwindcss/src/theme/utils.ts
+++ b/packages/@poupe-tailwindcss/src/theme/utils.ts
@@ -1,0 +1,86 @@
+import {
+  type Color,
+  type ThemeColorOptions,
+} from './types';
+
+import {
+  getShades,
+} from './shades';
+
+import {
+  hex,
+  standardPaletteKeys,
+} from '@poupe/theme-builder';
+
+export {
+  getShades,
+  validShade,
+} from './shades';
+
+export * from '../utils';
+
+/** @returns true if the given prefix is valid for theme CSS variables */
+export function validThemePrefix(prefix: string): boolean {
+  return !prefix || prefixRegex.test(prefix);
+}
+
+const prefixRegex = /^([a-z][0-9a-z]*)(-[a-z][0-9a-z]*)*-?$/;
+
+/** @returns true if the given suffix is valid for theme CSS variables */
+export function validThemeSuffix(suffix: string): boolean {
+  return !suffix || suffixRegex.test(suffix);
+}
+
+const suffixRegex = /^(-?[a-z][0-9a-z]*)(-[a-z][0-9a-z]*)*$/;
+
+/** @returns true if the name is a valid kebab-case color name */
+export function validColorName(name: string): boolean {
+  return colorNameRegex.test(name);
+}
+
+const colorNameRegex = /^([a-z][0-9a-z]*)(-[a-z][0-9a-z]*)*$/;
+
+/**
+ * Validates color options for a theme color.
+ *
+ * @param name - The name of the color
+ * @param options - Theme color configuration options
+ * @returns true if color options are valid, false otherwise
+ */
+export function validColorOptions(name: string, options: ThemeColorOptions): boolean {
+  const { ok: shadeOK } = getShades(options.shades);
+  if (!shadeOK) {
+    return false;
+  }
+
+  const { ok: colorOK } = getColor(name, options.value);
+  return colorOK;
+}
+
+export function getColor(name: string, value: Color | undefined): { ok: boolean; color?: string } {
+  const v = value ?? (name in standardPaletteKeys ? undefined : name);
+  if (v === undefined) {
+    // standard keys can be undefined.
+    // primary will take {@link defaultPrimaryColor},
+    // and the other colors will take the generated value.
+    return { ok: true };
+  }
+
+  try {
+    return { ok: true, color: hex(v) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function debugLog(enabled: boolean = false, ...a: unknown[]) {
+  if (enabled) {
+    console.log(logPrefix, ...a);
+  }
+}
+
+export function warnLog(...a: unknown[]) {
+  console.warn(logPrefix, ...a);
+}
+
+const logPrefix = '@poupe/tailwindcss';

--- a/packages/@poupe-tailwindcss/src/utils.ts
+++ b/packages/@poupe-tailwindcss/src/utils.ts
@@ -1,0 +1,1 @@
+export * from './utils/index';

--- a/packages/@poupe-tailwindcss/src/utils/builder.ts
+++ b/packages/@poupe-tailwindcss/src/utils/builder.ts
@@ -1,0 +1,15 @@
+export {
+  type KebabCase,
+  kebabCase,
+  unsafeKeys,
+} from '@poupe/theme-builder/utils';
+
+export {
+  type Color,
+  type CSSRuleObject,
+  Hct,
+
+  hct,
+  hslString,
+  splitHct,
+} from '@poupe/theme-builder/core';

--- a/packages/@poupe-tailwindcss/src/utils/config.ts
+++ b/packages/@poupe-tailwindcss/src/utils/config.ts
@@ -1,0 +1,32 @@
+import { type Config } from './plugin';
+
+export { type Config } from './plugin';
+
+export type DarkModeStrategy = Exclude<Config['darkMode'], undefined>;
+
+/**
+ * Converts a Tailwind dark mode strategy into the corresponding CSS selector or media query string.
+ * @param darkMode - The dark mode strategy to convert
+ * @returns A string representation for use in CSS selectors or media queries
+ */
+export function getDarkMode(darkMode: DarkModeStrategy = 'class'): string {
+  switch (darkMode) {
+    case false:
+      return '';
+    case 'media':
+      return 'media';
+    case 'class':
+      return '.dark';
+    default: {
+      if (Array.isArray(darkMode) && darkMode.length > 0) {
+        const [mode, value] = darkMode;
+        if (mode === 'class') {
+          return value || '.dark';
+        }
+        // TODO: implement selector and variant modes
+      }
+
+      throw new Error(`Invalid darkMode strategy: ${JSON.stringify(darkMode)}.`);
+    }
+  }
+}

--- a/packages/@poupe-tailwindcss/src/utils/index.ts
+++ b/packages/@poupe-tailwindcss/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './plugin';

--- a/packages/@poupe-tailwindcss/src/utils/index.ts
+++ b/packages/@poupe-tailwindcss/src/utils/index.ts
@@ -1,1 +1,3 @@
+export * from './builder';
+export * from './config';
 export * from './plugin';

--- a/packages/@poupe-tailwindcss/src/utils/plugin.test.ts
+++ b/packages/@poupe-tailwindcss/src/utils/plugin.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from 'vitest';
+
+test('dummy', () => {
+  expect(true).eq(true);
+});

--- a/packages/@poupe-tailwindcss/src/utils/plugin.ts
+++ b/packages/@poupe-tailwindcss/src/utils/plugin.ts
@@ -1,0 +1,61 @@
+import {
+  type Config,
+  type PluginAPI,
+
+  default as origPlugin,
+} from 'tailwindcss/plugin';
+
+/** re-export standard plugin types */
+export {
+  type Config,
+  type PluginAPI,
+  type PluginCreator as PluginFn,
+} from 'tailwindcss/plugin';
+
+export type PluginWithConfig = ReturnType<typeof origPlugin>;
+export type PluginWithOptions<O> = ReturnType<typeof origPlugin.withOptions<O>>;
+
+/**
+ * Creates a Tailwind plugin with configurable options.
+ *
+ * @typeParam O - The type of input configuration options (user-provided)
+ * @typeParam T - The type of processed options used by the plugin functions (internal)
+ * @param pluginFunction - Handles the plugin's core logic (addUtilities, etc.) using processed options T.
+ * @param configFunction - Generates partial Tailwind config using processed options T.
+ * @param processOptions - Processes user input O into the internal options T
+ * @returns A plugin function expecting user options O.
+ */
+export function pluginWithOptions<O, T>(
+  pluginFunction: (api: PluginAPI, options: T) => void,
+  configFunction?: (options: T) => Partial<Config>,
+  processOptions?: (options?: O) => T,
+): PluginWithOptions<O> {
+  function optionsFunction(options?: O): PluginWithConfig {
+    const $options = processOptions ? processOptions(options) : options as T;
+
+    return {
+      handler: (api: PluginAPI): void => pluginFunction(api, $options),
+      config: configFunction ? configFunction($options) : undefined,
+    };
+  };
+
+  optionsFunction.__isOptionsFunction = true as const;
+  return optionsFunction;
+};
+
+/**
+ * Creates a Tailwind plugin with partial configuration options.
+ *
+ * @typeParam T - The type of configuration options for the plugin
+ * @param pluginFunction - A function that generates the Tailwind plugin
+ * @param configFunction - A function that generates partial Tailwind configuration based on options
+ * @param defaultsFunction - A function that provides default options with partial configuration
+ * @returns A plugin function with partial configurable options
+ */
+export function pluginWithPartialOptions<T>(
+  pluginFunction: (api: PluginAPI, options: T) => void,
+  configFunction?: (options: T) => Partial<Config>,
+  defaultsFunction?: (options?: Partial<T>) => T,
+): PluginWithOptions<Partial<T>> {
+  return pluginWithOptions(pluginFunction, configFunction, defaultsFunction);
+};

--- a/packages/@poupe-tailwindcss/tsconfig.json
+++ b/packages/@poupe-tailwindcss/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true
+  },
+  "include": [
+    "src",
+  ]
+}

--- a/packages/@poupe-tailwindcss/vitest.config.ts
+++ b/packages/@poupe-tailwindcss/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node', // or 'jsdom' if your tests ever require a DOM
+    globals: true, // Optional: enables global APIs like describe, it, expect
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['text', 'json-summary', 'json', 'html'],
+      include: ['src/**/*.ts'], // Adjust based on your source code location
+      exclude: [
+        // Add patterns for files/directories to exclude from coverage
+        'src/index.ts', // Often entry points don't need coverage
+        '**/*.spec.ts',
+        '**/*.test.ts',
+        '**/__tests__/**',
+        '**/dist/**',
+      ],
+    },
+  },
+  // If you use path aliases in your project (e.g., in tsconfig.json),
+  // you might need to configure them here as well.
+  // resolve: {
+  //   alias: {
+  //     // Example: '@': path.resolve(__dirname, './src'),
+  //   },
+  // },
+});

--- a/packages/@poupe-theme-builder/package.json
+++ b/packages/@poupe-theme-builder/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@poupe/eslint-config": "^0.6.3",
     "eslint": "^9.26.0",
+    "publint": "^0.3.12",
     "typescript": "~5.8.3",
     "unbuild": "3.5.0",
     "vitest": "^3.1.3",

--- a/packages/@poupe-vue/package.json
+++ b/packages/@poupe-vue/package.json
@@ -67,6 +67,7 @@
     "npm-run-all2": "^8.0.1",
     "pathe": "^2.0.3",
     "postcss": "^8.5.3",
+    "publint": "^0.3.12",
     "typescript": "~5.8.3",
     "unplugin-vue-components": "^28.5.0",
     "vite": "^6.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       nuxt:
         specifier: ^3.17.2
         version: 3.17.2(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(db0@0.3.2)(eslint@9.26.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.29.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.1)(terser@5.39.0)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.7.1)
+      publint:
+        specifier: ^0.3.12
+        version: 0.3.12
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -125,6 +128,9 @@ importers:
       eslint:
         specifier: ^9.25.1
         version: 9.26.0(jiti@2.4.2)
+      publint:
+        specifier: ^0.3.12
+        version: 0.3.12
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -159,6 +165,9 @@ importers:
       eslint:
         specifier: ^9.26.0
         version: 9.26.0(jiti@2.4.2)
+      publint:
+        specifier: ^0.3.12
+        version: 0.3.12
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -253,6 +262,9 @@ importers:
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
+      publint:
+        specifier: ^0.3.12
+        version: 0.3.12
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -1378,6 +1390,10 @@ packages:
   '@poupe/eslint-config@0.6.3':
     resolution: {integrity: sha512-EPTFBhMH4+VhpXQ808D6YjyqV1wb9t5TYXGiNliV4s4hJdQoUgHefnP7IvLGAgNden2sypAunxTfsfnTlrT9aA==}
     engines: {node: '>= 18.20.8', pnpm: '>= 10.10.0'}
+
+  '@publint/pack@0.1.2':
+    resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
+    engines: {node: '>=18'}
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -4912,6 +4928,11 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  publint@0.3.12:
+    resolution: {integrity: sha512-1w3MMtL9iotBjm1mmXtG3Nk06wnq9UhGNRpQ2j6n1Zq7YAD6gnxMMZMIxlRPAydVjVbjSm+n0lhwqsD1m4LD5w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
@@ -5136,6 +5157,10 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -7652,6 +7677,8 @@ snapshots:
       - supports-color
       - typescript
       - vue-eslint-parser
+
+  '@publint/pack@0.1.2': {}
 
   '@rollup/plugin-alias@5.1.1(rollup@4.40.1)':
     optionalDependencies:
@@ -11574,6 +11601,13 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  publint@0.3.12:
+    dependencies:
+      '@publint/pack': 0.1.2
+      package-manager-detector: 1.1.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
@@ -11847,6 +11881,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   safe-buffer@5.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@poupe/eslint-config':
         specifier: ^0.6.3
         version: 0.6.3(jiti@2.4.2)(typescript@5.8.3)(vue-eslint-parser@10.1.1(eslint@9.26.0(jiti@2.4.2)))
+      '@poupe/theme-builder':
+        specifier: workspace:^
+        version: link:../@poupe-theme-builder
       eslint:
         specifier: ^9.25.1
         version: 9.26.0(jiti@2.4.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,31 @@ importers:
         specifier: ^3.25.0
         version: 3.25.0
 
+  packages/@poupe-tailwindcss:
+    dependencies:
+      tailwindcss:
+        specifier: ^4.1.5
+        version: 4.1.5
+    devDependencies:
+      '@poupe/eslint-config':
+        specifier: ^0.6.3
+        version: 0.6.3(jiti@2.4.2)(typescript@5.8.3)(vue-eslint-parser@10.1.1(eslint@9.26.0(jiti@2.4.2)))
+      eslint:
+        specifier: ^9.25.1
+        version: 9.26.0(jiti@2.4.2)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+      unbuild:
+        specifier: 3.5.0
+        version: 3.5.0(typescript@5.8.3)(vue-sfc-transformer@0.1.10(esbuild@0.25.3)(vue@3.5.13(typescript@5.8.3)))(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))
+      vitest:
+        specifier: ^3.1.2
+        version: 3.1.3(@types/node@22.15.3)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.29.1)(terser@5.39.0)(yaml@2.7.1)
+      vue-tsc:
+        specifier: ^2.2.10
+        version: 2.2.10(typescript@5.8.3)
+
   packages/@poupe-theme-builder:
     dependencies:
       '@material/material-color-utilities':
@@ -5442,6 +5467,9 @@ packages:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  tailwindcss@4.1.5:
+    resolution: {integrity: sha512-nYtSPfWGDiWgCkwQG/m+aX83XCwf62sBgg3bIlNiiOcggnS1x3uVRDAuyelBFL+vJdOPPCGElxv9DjHJjRHiVA==}
 
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -12182,6 +12210,8 @@ snapshots:
       sucrase: 3.35.0
     transitivePeerDependencies:
       - ts-node
+
+  tailwindcss@4.1.5: {}
 
   tapable@2.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       tailwind-scrollbar:
         specifier: ^4.0.2
         version: 4.0.2(react@19.0.0)(tailwindcss@3.4.17)
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.17
     devDependencies:
       '@nuxt/devtools':
         specifier: ^2.4.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `@poupe/tailwindcss` package as a Tailwind CSS v4 plugin integrating with the Poupe theme builder.
  - Added customizable theme and color configuration supporting dark and light modes, including color shades and palette management.
  - Provided enhanced plugin interfaces with options for flat and theme-based configurations.
  - Included utilities for theme validation, color processing, and dark mode strategy handling.

- **Documentation**
  - Added package metadata, build configuration, TypeScript setup, and Vitest testing configuration.

- **Tests**
  - Added initial test suites for theme and flat plugins, including basic placeholder tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->