### PR TITLE
feat(poupe-tailwindcss): implement default flat plugin, surface components and writeTheme()

### DIFF
--- a/packages/@poupe-tailwindcss/package.json
+++ b/packages/@poupe-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/tailwindcss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "tailwindcss v4 plugin to use poupe theme builder",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-tailwindcss/src/flat/plugin.ts
+++ b/packages/@poupe-tailwindcss/src/flat/plugin.ts
@@ -1,30 +1,328 @@
 import {
-  type PluginAPI,
+  type ThemeOptions,
+  type ThemeColorOptions,
+
+  themePluginFunction,
+  themeConfigFunction,
+  makeThemeFromPartialOptions,
+
+  defaultShades,
+} from '../theme/index';
+
+import {
+  flattenColorOptions,
+} from '../theme/options';
+
+import {
   type PluginWithOptions,
   pluginWithOptions,
-} from '../utils/plugin';
 
-export type FlatOptions = unknown & {};
+  validThemePrefix,
+  validThemeSuffix,
+  validColorName,
+  validColorOptions,
+} from '../theme/utils';
+
+import {
+  getBooleanValue,
+  getStringValue,
+  kebabCase,
+} from './utils';
+
+export type FlatOptions = {
+  /** Enables options parser logs */
+  debug?: boolean
+
+  /**
+   * Prefix used for color CSS variables
+   * @defaultValue 'md-'
+   */
+  themePrefix?: string
+
+  /**
+   * When true, only generates variable references without color values
+   * @defaultValue false
+   **/
+  omitTheme?: boolean
+
+  /** @defaultValue `''` */
+  darkSuffix?: string
+
+  /** @defaultValue `''` */
+  lightSuffix?: string
+
+  /** @defaultValue [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950] */
+  shades?: number[] | false
+} & {
+  /**
+   * Color configuration options. Supported formats:
+   *
+   * - `string`: Define color using colord-compatible value or name
+   * - `boolean`: Whether to harmonize known-color with primary
+   * - `number[]`: Custom shades (0 disables, negative adds to defaults)
+   * - `[boolean, ...number[]]`: Harmonize flag with custom shades
+   * - `[string, ...number[]]`: Custom color with custom shades
+   * - `[string, boolean, ...number[]]`: Custom color with harmonize flag
+   *   and custom shades
+   *
+   * Colors are harmonized by default using colord for parsing.
+   */
+  [color: string]: PluginColorOptions
+};
+
+export type PluginColorOptions = string | boolean |
+  [ ...number[] ] |
+  [boolean, ...number[]] |
+  [string, boolean] |
+  [string, boolean, ...number[]] |
+  [string, ...number[]];
 
 /** poupe plugin for tailwindcss v4 embedded in the default CSS */
 export const flatPlugin: PluginWithOptions<FlatOptions> = pluginWithOptions(
-  pluginFunction,
-  configFunction,
-  defaultsFunction,
+  themePluginFunction,
+  themeConfigFunction,
+  (params?: FlatOptions) => makeThemeFromPartialOptions(makeOptions(params)),
 );
 
-function pluginFunction(api: PluginAPI, options: FlatOptions): void {
-  console.log(`${logPrefix}:pluginFunction`, options, api);
-};
+/** @returns a partial {@link ThemeOptions} pre-populated from the
+ * parameters given to the {@link defaultPlugin}
+ * */
+export function makeOptions(params: FlatOptions = {}): Partial<ThemeOptions> {
+  const debug = params.debug ?? false;
 
-function configFunction(options: FlatOptions): FlatOptions {
-  console.log(`${logPrefix}:configFunction`, options);
+  debugLog(debug, 'params', params);
+
+  const options: Partial<ThemeOptions> = {};
+
+  for (const [key, value] of Object.entries(params)) {
+    if (!(processParam(options, debug, key, value))) {
+      warnLog('invalid param:', key, value);
+    }
+  }
+
+  debugLog(debug, 'options', options);
+
   return options;
 }
 
-function defaultsFunction(options: FlatOptions = {}): FlatOptions {
-  console.log(`${logPrefix}:defaultsFunction`, options);
-  return options;
+/** @returns true if the value was accepted for the specified key */
+export function processParam(options: Partial<ThemeOptions>, debug: boolean, key: string, value: unknown): boolean {
+  switch (key) {
+    case 'debug': {
+      const v = getBooleanValue(value);
+      if (v === undefined) {
+        return false;
+      }
+      options.debug = v;
+      debugLog(debug, 'debug', v);
+      return true;
+    }
+
+    case 'themePrefix':
+    case 'theme-prefix': {
+      const v = getStringValue(value);
+      if (v === undefined || !validThemePrefix(v)) {
+        return false;
+      }
+      options.themePrefix = v;
+      debugLog(debug, 'theme-prefix', v);
+      return true;
+    }
+
+    case 'omitTheme':
+    case 'omit-theme': {
+      const v = getBooleanValue(value);
+      if (v === undefined) {
+        return false;
+      }
+      options.omitTheme = v;
+      debugLog(debug, 'omit-theme', v);
+      return true;
+    }
+
+    case 'darkSuffix':
+    case 'dark-suffix': {
+      const v = getStringValue(value);
+      if (v === undefined || !validThemeSuffix(v)) {
+        return false;
+      }
+      options.darkSuffix = v;
+      debugLog(debug, 'dark-suffix', v);
+      return true;
+    }
+
+    case 'lightSuffix':
+    case 'light-suffix': {
+      const v = getStringValue(value);
+      if (v === undefined || !validThemeSuffix(v)) {
+        return false;
+      }
+      options.lightSuffix = v;
+      debugLog(debug, 'light-suffix', v);
+      return true;
+    }
+
+    case 'shades':
+      return processShadesParam(options, debug, value);
+    default:
+      return processColorParam(options, debug, key, value);
+  }
 }
 
-const logPrefix = '@poupe/tailwindcss/flat';
+function processColorParam(options: Partial<ThemeOptions>, debug: boolean, key: string, value: unknown): boolean {
+  const colorName = kebabCase(key);
+  const colorOptions: ThemeColorOptions = {};
+
+  if (!validColorName(colorName)) {
+    return false;
+  } else if (typeof value === 'string') {
+    if (value === '') {
+      return false;
+    }
+    colorOptions.value = value;
+  } else if (typeof value === 'boolean') {
+    colorOptions.harmonized = value;
+  } else if (!Array.isArray(value)) {
+    return false;
+  } else if (!processColorParamArray(colorOptions, debug, value)) {
+    return false;
+  }
+
+  if (options.colors === undefined) {
+    options.colors = { primary: {} };
+  }
+
+  const mergedOptions: ThemeColorOptions = {
+    ...flattenColorOptions(options.colors[colorName]),
+    ...colorOptions,
+  };
+
+  if (!validColorOptions(colorName, mergedOptions)) {
+    return false;
+  }
+
+  options.colors[colorName] = mergedOptions;
+
+  debugLog(debug, 'color', colorName, mergedOptions);
+  return true;
+}
+
+function processColorParamArray(options: ThemeColorOptions, debug: boolean, values: unknown[]): boolean {
+  if (values.length === 0) {
+    // empty, invalid.
+    return false;
+  } else if (typeof values[0] === 'boolean') {
+    // [boolean, ...number[]]
+    options.harmonized = values[0];
+    return processColorParamShades(options, debug, values.slice(1));
+  } else if (typeof values[0] === 'number') {
+    // [...number[]]
+    return processColorParamShades(options, debug, values);
+  } else if (typeof values[0] !== 'string') {
+    // invalid.
+    return false;
+  }
+
+  options.value = values[0];
+  values = values.slice(1);
+  if (values.length === 0) {
+    // [string]
+    return true;
+  }
+
+  if (typeof values[0] === 'boolean') {
+    options.harmonized = values[0];
+    values = values.slice(1);
+    if (values.length === 0) {
+      // [string, boolean]
+      return true;
+    }
+
+    // [string, boolean, ...number[]]
+    // fallthrough
+  }
+
+  // [string, ...number[]]
+  return processColorParamShades(options, debug, values);
+}
+
+function processColorParamShades(options: ThemeColorOptions, debug: boolean, values: unknown[]): boolean {
+  if (values.length === 0) {
+    // empty, invalid.
+    return false;
+  } else if (values.length === 1 && values[0] === 0) {
+    // disable.
+    options.shades = false;
+    return true;
+  }
+
+  const shades = new Set<number>();
+  let append = false;
+
+  for (const v of values) {
+    let shade = getShadeValue(v, true); // allow negatives
+
+    if (shade === undefined) {
+      // invalid shade value
+      return false;
+    } else if (shade < 0) {
+      // append to defaults
+      append = true;
+      shade = -shade;
+    }
+
+    shades.add(shade);
+  }
+
+  // unique and sorted
+  if (append) {
+    for (const shade of defaultShades) {
+      shades.add(shade);
+    }
+  }
+  options.shades = [...shades].sort((a, b) => a - b);
+  return true;
+}
+
+function processShadesParam(options: Partial<ThemeOptions>, debug: boolean, value: unknown): boolean {
+  if (value === false || value === 0) {
+    // disable shades
+    options.shades = false;
+  } else if (value === true) {
+    // default shades
+    options.shades = defaultShades;
+  } else if (Array.isArray(value)) {
+    // use given shades array
+    const shades = new Set<number>();
+
+    for (const v of value) {
+      const shade = getShadeValue(v);
+      if (shade === undefined) {
+        // invalid shade value
+        return false;
+      }
+      shades.add(shade);
+    }
+
+    // unique and sorted
+    options.shades = [...shades].sort((a, b) => a - b);
+  } else {
+    // single shade?
+    const v = getShadeValue(value);
+    if (v === undefined) {
+      // invalid shade value
+      return false;
+    }
+    options.shades = [v];
+  }
+
+  debugLog(debug, 'shades', options.shades);
+  return true;
+}
+
+import {
+  debugLog,
+  warnLog,
+
+  getShadeValue,
+} from './utils';

--- a/packages/@poupe-tailwindcss/src/flat/utils.ts
+++ b/packages/@poupe-tailwindcss/src/flat/utils.ts
@@ -1,0 +1,46 @@
+import {
+  validShade,
+} from '../theme/shades';
+
+export * from '../utils';
+
+export function getShadeValue(value: unknown, negative: boolean = false): number | undefined {
+  if (typeof value !== 'number' || Math.round(value) !== value) {
+    return undefined;
+  } else if (validShade(value)) {
+    return value;
+  } else if (negative && validShade(-value)) {
+    return -value;
+  }
+  return undefined;
+}
+
+export function getStringValue(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return undefined;
+}
+
+export function getBooleanValue(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  } else if (value === 'true') {
+    return true;
+  } else if (value === 'false') {
+    return false;
+  }
+
+  return undefined;
+}
+export function debugLog(enabled: boolean, ...a: unknown[]) {
+  if (enabled) {
+    console.log(logPrefix, ...a);
+  }
+}
+
+export function warnLog(...a: unknown[]) {
+  console.warn(logPrefix, ...a);
+}
+
+const logPrefix = '@poupe/tailwindcss/flat';

--- a/packages/@poupe-tailwindcss/src/theme/components.ts
+++ b/packages/@poupe-tailwindcss/src/theme/components.ts
@@ -1,0 +1,97 @@
+import {
+  type Theme,
+} from './types';
+
+import {
+  type CSSRuleObject,
+  debugLog,
+} from './utils';
+
+export function makeThemeComponents(theme: Readonly<Theme>, tailwindPrefix: string = ''): Record<string, CSSRuleObject>[] {
+  return [
+    makeSurfaceComponents(theme, tailwindPrefix),
+  ];
+}
+
+export function makeSurfaceComponents(theme: Readonly<Theme>, tailwindPrefix: string = ''): Record<string, CSSRuleObject> {
+  // find surface pairs
+  const pairs = new Map<string, string>();
+  for (const name of theme.keys) {
+    if (theme.colors[name] && theme.colors[`on-${name}`]) {
+      pairs.set(name, `on-${name}`);
+    }
+  }
+
+  debugLog(theme.options.debug, 'makeSurfaceComponents', pairs);
+
+  // TODO: determine pair of special colors
+  // - primary-fixed-dim
+  // - on-primary-fixed-variant
+  // - secondary-fixed-dim
+  // - on-secondary-fixed-variant
+  // - tertiary-fixed-dim
+  // - on-tertiary-fixed-variant
+
+  const surfaces: Record<string, CSSRuleObject> = {};
+
+  // TODO: make prefixes configurable
+  const [bgPrefix, textPrefix, surfacePrefix] = ['bg-', 'text-', 'surface-'].map(prefix => `${tailwindPrefix}${prefix}`);
+
+  for (const [name, onName] of pairs) {
+    const { key, value } = assembleSurfaceComponent(name, onName, bgPrefix, textPrefix, surfacePrefix);
+    surfaces[key] = value;
+  }
+
+  return surfaces;
+}
+
+/**
+ * Assembles a surface component by combining background and text color classes.
+ *
+ * @param colorName - The base color name for the background
+ * @param onColorName - The color name for text on the surface
+ * @param bgPrefix - Prefix for background color classes
+ * @param textPrefix - Prefix for text color classes
+ * @param surfacePrefix - Prefix for surface classes
+ * @returns An object with a key for the surface class and its corresponding CSS rule object
+ */
+export function assembleSurfaceComponent(
+  colorName: string,
+  onColorName: string,
+  bgPrefix: string,
+  textPrefix: string,
+  surfacePrefix: string,
+): { key: string; value: CSSRuleObject } {
+  if (surfacePrefix === bgPrefix) {
+    // extend bg- with text-on-
+    return {
+      key: `.${bgPrefix}${colorName}`,
+      value: {
+        [`@apply ${textPrefix}${onColorName}`]: {},
+      },
+    };
+  }
+  // combine bg- and text-on-
+  const surfaceName = makeSurfaceName(colorName, surfacePrefix);
+  return {
+    key: `.${surfaceName}`,
+    value: {
+      [`@apply ${bgPrefix}${colorName} ${textPrefix}${onColorName}`]: {},
+    },
+  };
+}
+
+/**
+ * Generates a surface name by prefixing a color name with a given prefix.
+ *
+ * @param colorName - The original color name to be transformed
+ * @param prefix - The prefix to be added to the color name
+ * @returns A surface name that avoids prefix duplication
+ */
+export function makeSurfaceName(colorName: string, prefix: string): string {
+  if (colorName.startsWith(prefix) || `${colorName}-` === prefix) {
+    // prevent duplication
+    return colorName;
+  }
+  return `${prefix}${colorName}`;
+}

--- a/packages/@poupe-tailwindcss/src/theme/css.ts
+++ b/packages/@poupe-tailwindcss/src/theme/css.ts
@@ -1,0 +1,113 @@
+import {
+  type Theme,
+  type ThemeColorConfig,
+} from './types';
+
+import {
+  type CSSRuleObject,
+  type DarkModeStrategy,
+  formatCSSRuleObjects,
+  unsafeKeys,
+} from './utils';
+
+import {
+  makeThemeBases,
+  makeThemeComponents,
+} from './theme';
+
+import {
+  defaultPersistentColors,
+} from './config';
+
+function writeRulesSet(out: Buffer, key: string, rules: CSSRuleObject[], indent: string = '  ', newLine: string = '\n', prefix: string = '') {
+  const nextPrefix = `${prefix}${indent}`;
+
+  out.write(`${prefix}${key} {${newLine}`);
+  for (const [i, entry] of rules.entries()) {
+    out.write(formatCSSRuleObjects(entry, indent, newLine, nextPrefix));
+    out.write(newLine);
+    if (i < rules.length - 1) {
+      out.write(newLine);
+    }
+  }
+  out.write(`${prefix}}${newLine}`);
+}
+
+function writeUtilities(out: Buffer, u: CSSRuleObject, indent: string = '  ', newLine: string = '\n', prefix: string = '') {
+  const utilities: CSSRuleObject = {};
+  for (const [name, value] of Object.entries(u)) {
+    utilities[`@utility ${name}`] = value;
+  }
+
+  out.write(formatCSSRuleObjects(utilities, indent, newLine, prefix));
+  out.write(newLine);
+}
+
+export function writeTheme(
+  theme: Theme,
+  out: Buffer,
+  darkMode: DarkModeStrategy = 'class',
+  indent: string = '  ',
+  newLine: string = '\n',
+) {
+  const { extendColors = false } = theme.options;
+
+  const bases = makeThemeBases(theme, darkMode);
+  const themeColorRules = themeColors(theme.colors, extendColors);
+  const components = makeThemeComponents(theme);
+
+  // bases
+  writeRulesSet(out, '@layer base', bases, indent, newLine);
+  out.write(newLine);
+
+  // theme
+  writeRulesSet(out, '@theme', themeColorRules, indent, newLine);
+  out.write(newLine);
+
+  // components
+  for (const [i, entry] of components.entries()) {
+    writeUtilities(out, entry, indent, newLine);
+
+    if (i < components.length - 1) {
+      out.write(newLine);
+    }
+  }
+}
+
+export function themeColors(
+  colors: Record<string, ThemeColorConfig>,
+  extendColors: boolean = false,
+  persistentColors: Record<string, string> = defaultPersistentColors,
+): CSSRuleObject[] {
+  const rules: CSSRuleObject[] = [];
+
+  if (!extendColors) {
+    const out: CSSRuleObject = {};
+
+    // reset
+    rules.push({ '--color-*': 'initial' });
+
+    // persistent colors not customized
+    for (const key of unsafeKeys(persistentColors).sort((a, b) => a.localeCompare(b))) {
+      if (!(key in colors)) {
+        out[`--color-${key}`] = persistentColors[key];
+      }
+    }
+    rules.push(out);
+  }
+
+  // custom colors
+  const out: CSSRuleObject = {};
+  for (const key of unsafeKeys(colors).sort((a, b) => a.localeCompare(b))) {
+    const c = colors[key];
+    out[`--color-${key}`] = `var(${c.value})`;
+    if (c.shades) {
+      // shades
+      for (const shade of unsafeKeys(c.shades).sort((a, b) => a - b)) {
+        out[`--color-${key}-${shade}`] = `var(${c.shades[shade]})`;
+      }
+    }
+  }
+  rules.push(out);
+  return rules;
+}

--- a/packages/@poupe-tailwindcss/src/theme/index.ts
+++ b/packages/@poupe-tailwindcss/src/theme/index.ts
@@ -21,3 +21,7 @@ export {
   type Config,
   makeConfig,
 } from './config';
+
+export {
+  writeTheme,
+} from './css';

--- a/packages/@poupe-tailwindcss/src/theme/plugin.ts
+++ b/packages/@poupe-tailwindcss/src/theme/plugin.ts
@@ -36,7 +36,8 @@ export function themePluginFunction(api: PluginAPI, theme: Theme): void {
   for (const base of makeThemeBases(theme, darkMode)) {
     api.addBase(base);
   }
-  api.addComponents(makeThemeComponents(theme));
+
+  api.addComponents(makeThemeComponents(theme, api.config('prefix', '')));
 }
 
 /** alias of makeConfig as companion for themePluginFunction */

--- a/packages/@poupe-tailwindcss/src/theme/theme.ts
+++ b/packages/@poupe-tailwindcss/src/theme/theme.ts
@@ -37,6 +37,10 @@ export {
   type Theme,
 } from './types';
 
+export {
+  makeThemeComponents,
+} from './components';
+
 /**
  * Creates a theme configuration based on the provided theme options.
  *
@@ -202,10 +206,4 @@ export function makeThemeBases(
   }
 
   return bases;
-}
-
-export function makeThemeComponents(theme: Readonly<Theme>): Record<string, CSSRuleObject>[] {
-  debugLog(theme.options.debug, 'makeThemeComponents', theme);
-  // TODO: implement
-  return [];
 }

--- a/packages/@poupe-tailwindcss/src/utils/builder.ts
+++ b/packages/@poupe-tailwindcss/src/utils/builder.ts
@@ -12,4 +12,5 @@ export {
   hct,
   hslString,
   splitHct,
+  formatCSSRuleObjects,
 } from '@poupe/theme-builder/core';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a comprehensive theming plugin for Tailwind CSS with advanced color and shade configuration options.
  - Added utilities for validating and processing theme options, including support for flexible color formats and shade arrays.
  - Added functions to generate CSS components and color rules based on theme configurations, supporting customizable prefixes and persistent colors.

- **Refactor**
  - Replaced placeholder plugin logic with a robust, fully-featured theming implementation.
  - Modularized theme component and CSS generation for improved maintainability and extensibility.

- **Chores**
  - Updated package version to 0.2.0.
  - Improved and expanded exports for utility and theme-related functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->