### PR TITLE
feat(poupe-tailwindcss): rename contrast to contrastLevel, reduce writeTheme's output and improve logs

### DIFF
--- a/packages/@poupe-tailwindcss/package.json
+++ b/packages/@poupe-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/tailwindcss",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "tailwindcss v4 plugin to use poupe theme builder",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-tailwindcss/src/theme/components.ts
+++ b/packages/@poupe-tailwindcss/src/theme/components.ts
@@ -22,8 +22,6 @@ export function makeSurfaceComponents(theme: Readonly<Theme>, tailwindPrefix: st
     }
   }
 
-  debugLog(theme.options.debug, 'makeSurfaceComponents', pairs);
-
   // TODO: determine pair of special colors
   // - primary-fixed-dim
   // - on-primary-fixed-variant
@@ -42,6 +40,7 @@ export function makeSurfaceComponents(theme: Readonly<Theme>, tailwindPrefix: st
     surfaces[key] = value;
   }
 
+  debugLog(theme.options.debug, 'surfaces', surfaces);
   return surfaces;
 }
 

--- a/packages/@poupe-tailwindcss/src/theme/css.ts
+++ b/packages/@poupe-tailwindcss/src/theme/css.ts
@@ -57,8 +57,10 @@ export function writeTheme(
   const components = makeThemeComponents(theme);
 
   // bases
-  writeRulesSet(out, '@layer base', bases, indent, newLine);
-  out.write(newLine);
+  if (bases.length > 0) {
+    writeRulesSet(out, '@layer base', bases, indent, newLine);
+    out.write(newLine);
+  }
 
   // theme
   writeRulesSet(out, '@theme', themeColorRules, indent, newLine);

--- a/packages/@poupe-tailwindcss/src/theme/options.ts
+++ b/packages/@poupe-tailwindcss/src/theme/options.ts
@@ -5,7 +5,7 @@ import {
 
   defaultPrimaryColor,
   defaultThemeScheme,
-  defaultThemeContrast,
+  defaultThemeContrastLevel,
   defaultThemePrefix,
   defaultThemeDarkSuffix,
   defaultThemeLightSuffix,
@@ -47,7 +47,7 @@ export function withDefaultThemeOptions<K extends string = string>(options: Part
     darkSuffix: options.darkSuffix ?? defaultThemeDarkSuffix,
     lightSuffix: options.lightSuffix ?? defaultThemeLightSuffix,
     scheme: options.scheme ?? defaultThemeScheme,
-    contrast: options.contrast ?? defaultThemeContrast,
+    contrastLevel: options.contrastLevel ?? defaultThemeContrastLevel,
 
     shades,
     colors,

--- a/packages/@poupe-tailwindcss/src/theme/plugin.ts
+++ b/packages/@poupe-tailwindcss/src/theme/plugin.ts
@@ -30,14 +30,18 @@ export const themePlugin: PluginWithOptions<Partial<ThemeOptions>> = pluginWithO
 
 /** uses Tailwind CSS's PluginAPI to apply a Theme */
 export function themePluginFunction(api: PluginAPI, theme: Theme): void {
-  debugLog(theme.options.debug, 'plugin', theme);
-
   const darkMode = api.config('darkMode', 'class') as DarkModeStrategy;
+
+  debugLog(theme.options.debug, 'plugin', `darkMode:${darkMode}`, theme.paletteKeys);
+
   for (const base of makeThemeBases(theme, darkMode)) {
     api.addBase(base);
   }
 
-  api.addComponents(makeThemeComponents(theme, api.config('prefix', '')));
+  for (const components of makeThemeComponents(theme, api.config('prefix', ''))) {
+    debugLog(theme.options.debug, 'plugin', components);
+    api.addComponents(components);
+  }
 }
 
 /** alias of makeConfig as companion for themePluginFunction */

--- a/packages/@poupe-tailwindcss/src/theme/theme.ts
+++ b/packages/@poupe-tailwindcss/src/theme/theme.ts
@@ -68,7 +68,7 @@ export function makeTheme<K extends string>(options: ThemeOptions<K>) {
     dark,
     light,
     darkPalette,
-  } = makeThemeColors($colors, options.scheme, options.contrast);
+  } = makeThemeColors($colors, options.scheme, options.contrastLevel);
 
   const keys = unsafeKeys(dark);
   const paletteKeys = unsafeKeys(darkPalette);

--- a/packages/@poupe-tailwindcss/src/theme/theme.ts
+++ b/packages/@poupe-tailwindcss/src/theme/theme.ts
@@ -9,6 +9,7 @@ import {
   type DarkModeStrategy,
   unsafeKeys,
   getDarkMode,
+  hexString,
   hslString,
   debugLog,
 } from './utils';
@@ -185,7 +186,13 @@ export function makeThemeBases(
   theme: Readonly<Theme>,
   darkMode: DarkModeStrategy = 'class',
 ): CSSRuleObject[] {
-  debugLog(theme.options.debug, 'makeThemeBases', darkMode, theme);
+  if (theme.options.debug) {
+    debugLog(true, 'makeThemeBases', `darkMode:${darkMode}`, {
+      ...theme,
+      dark: theme.dark ? Object.fromEntries(Object.entries(theme.dark).map(([k, v]) => [k, hexString(v)])) : undefined,
+      light: theme.light ? Object.fromEntries(Object.entries(theme.light).map(([k, v]) => [k, hexString(v)])) : undefined,
+    });
+  }
 
   const bases: CSSRuleObject[] = [];
 

--- a/packages/@poupe-tailwindcss/src/theme/types.ts
+++ b/packages/@poupe-tailwindcss/src/theme/types.ts
@@ -63,7 +63,7 @@ export type ThemeOptions<K extends string = string> = {
   scheme: StandardDynamicSchemeKey
 
   /** Theme contrast level, @defaultValue `0` */
-  contrast: number
+  contrastLevel: number
 
   /** Suffix for dark theme variants, @defaultValue `''` */
   darkSuffix: string
@@ -115,5 +115,5 @@ export const defaultPrimaryColor = '#74bef5'; // blue from Tailwind CSS's logo
 export const defaultThemePrefix = 'md-';
 export const defaultThemeDarkSuffix = '';
 export const defaultThemeLightSuffix = '';
-export const defaultThemeContrast = 0;
+export const defaultThemeContrastLevel = 0;
 export const defaultThemeScheme: StandardDynamicSchemeKey = 'content';

--- a/packages/@poupe-tailwindcss/src/utils/builder.ts
+++ b/packages/@poupe-tailwindcss/src/utils/builder.ts
@@ -10,6 +10,7 @@ export {
   Hct,
 
   hct,
+  hex as hexString,
   hslString,
   splitHct,
   formatCSSRuleObjects,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the theme option property from "contrast" to "contrastLevel" for improved clarity and consistency.
  - Updated related type definitions and constants to match the new property name.
  - Adjusted internal usage to reflect the property rename.

- **Bug Fixes**
  - Prevented output of empty CSS blocks when no base rules are present.

- **Chores**
  - Improved and reorganized debug logging for better clarity during development.
  - Incremented the package version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->