### PR TITLE
feat(poupe-css): introduce @poupe/css

### DIFF
--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -1,0 +1,173 @@
+# @poupe/css
+
+[![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@poupe/css)
+
+A TypeScript utility library for CSS property manipulation and formatting.
+
+## Installation
+
+```bash
+npm install @poupe/css
+```
+
+## API Reference
+
+### Types
+
+#### `CSSValue`
+Represents a valid CSS property value:
+```typescript
+type CSSValue = string | number | (string | number)[];
+```
+
+#### `CSSProperties<K extends string = string>`
+A typed record of CSS properties:
+```typescript
+type CSSProperties<K extends string = string> = Record<K, CSSValue>;
+```
+
+#### `CSSPropertiesOptions`
+Configuration options for CSS properties stringification:
+```typescript
+type CSSPropertiesOptions = {
+  /** Indentation string, defaults to two spaces. */
+  indent?: string
+  /** Prefix string added before each line, defaults to empty string. */
+  prefix?: string
+  /** New line character, defaults to LF. */
+  newLine?: string
+  /** Whether to format output on a single line, defaults to false. */
+  inline?: boolean
+  /** Maximum number of properties to format on a single line, defaults to 1. */
+  singleLineThreshold?: number
+}
+```
+
+### CSS Property Functions
+
+#### `stringifyCSSProperties<K extends string>(object: CSSProperties<K>, options?: CSSPropertiesOptions): string`
+Converts a CSSProperties object into a formatted CSS string representation with proper indentation.
+
+```typescript
+import { stringifyCSSProperties } from '@poupe/css';
+
+const styles = {
+  fontSize: '16px',
+  backgroundColor: 'red',
+  margin: [10, '20px', '30px', '40px']
+};
+
+// Default multi-line formatting
+const cssString = stringifyCSSProperties(styles);
+// "{
+//   font-size: 16px;
+//   background-color: red;
+//   margin: 10, 20px, 30px, 40px;
+//   }"
+
+// Inline formatting
+const inlineCSS = stringifyCSSProperties(styles, { inline: true });
+// "{ font-size: 16px; background-color: red; margin: 10, 20px, 30px, 40px }"
+
+// Custom indentation and prefix
+const customCSS = stringifyCSSProperties(styles, { 
+  indent: '    ',
+  prefix: '  ',
+  singleLineThreshold: 3
+});
+// "{
+//       font-size: 16px;
+//       background-color: red;
+//       margin: 10, 20px, 30px, 40px;
+//   }"
+```
+
+#### `formatCSSProperties<K extends string>(object: CSSProperties<K>): string[]`
+Formats a CSS properties object into an array of CSS property strings.
+
+```typescript
+import { formatCSSProperties } from '@poupe/css';
+
+const styles = {
+  fontSize: '16px',
+  backgroundColor: 'red',
+  margin: [10, '20px', '30px', '40px']
+};
+
+const cssLines = formatCSSProperties(styles);
+// [
+//   "font-size: 16px",
+//   "background-color: red",
+//   "margin: 10, 20px, 30px, 40px"
+// ]
+```
+
+#### `formatCSSValue(value: CSSValue): string`
+Formats a CSS value into a string. If the value is an array, it joins the elements with a comma and a space.
+If the value is a string containing spaces, it encloses the string in double quotes.
+
+```typescript
+import { formatCSSValue } from '@poupe/css';
+
+formatCSSValue('16px'); // "16px"
+formatCSSValue('Open Sans'); // "\"Open Sans\""
+formatCSSValue([10, '20px', '30px']); // "10, 20px, 30px"
+```
+
+#### `properties<K extends string>(object: CSSProperties<K>): Generator<[K, CSSValue]>`
+Generates a sequence of valid CSS property key-value pairs from a CSSProperties object.
+Filters out invalid or empty CSS property values.
+
+```typescript
+import { properties } from '@poupe/css';
+
+const styles = {
+  fontSize: '16px',
+  backgroundColor: 'red',
+  _private: 'hidden',
+  empty: ''
+};
+
+// Iterate through valid properties only
+for (const [key, value] of properties(styles)) {
+  console.log(`${key}: ${value}`);
+}
+// Output:
+// fontSize: 16px
+// backgroundColor: red
+```
+
+### Utility Functions
+
+#### `unsafeKeys<T>(object: T): Array<keyof T>`
+A type-safe wrapper around Object.keys that preserves the object's key types.
+
+#### `keys<T, K extends keyof T>(object: T, valid?: (key: keyof T) => boolean): Generator<K>`
+A generator function that yields keys of an object that pass an optional validation function.
+
+#### `pairs<K extends string, T1, T2>(object: Record<K, T1>, valid?: (k: K, v: T1) => boolean): Generator<[K, T2]>`
+A generator function that yields valid key-value pairs from an object.
+
+#### `defaultValidPair<K extends string, T>(key: K, value: T): boolean`
+Validates if a key-value pair meets default criteria:
+- The value is neither null nor undefined
+- The key doesn't contain spaces
+- The key doesn't start with an underscore (_)
+
+#### `kebabCase(s: string): string`
+Converts a given string to kebab-case:
+- Transforms camelCase, PascalCase, and snake_case to kebab-case
+- Adds leading hyphen to recognized vendor prefixes
+
+```typescript
+import { kebabCase } from '@poupe/css';
+
+kebabCase('XMLHttpRequest'); // 'xml-http-request'
+kebabCase('camelCase');      // 'camel-case'
+kebabCase('snake_case');     // 'snake-case'
+kebabCase('WebkitTransition'); // '-webkit-transition'
+```
+
+## License
+
+MIT licensed.

--- a/packages/@poupe-css/build.config.ts
+++ b/packages/@poupe-css/build.config.ts
@@ -1,0 +1,5 @@
+import { defineBuildConfig } from 'unbuild';
+
+export default defineBuildConfig({
+  sourcemap: true,
+});

--- a/packages/@poupe-css/package.json
+++ b/packages/@poupe-css/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@poupe/css",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "A TypeScript utility library for CSS property manipulation, formatting, and CSS-in-JS operations",
+  "author": "Alejandro Mery <amery@apptly.co>",
+  "license": "MIT",
+  "keywords": [
+    "css",
+    "css-in-js",
+    "typescript",
+    "styling",
+    "formatter",
+    "css-properties",
+    "css-utilities",
+    "kebab-case",
+    "stringify",
+    "poupe"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/poupe-ui/poupe.git",
+    "directory": "packages/@poupe-css"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepack": "run-s lint type-check test build publint",
+    "dev:prepare": "unbuild --stub",
+    "type-check": "tsc --noEmit",
+    "lint": "env DEBUG=eslint:eslint eslint --fix .",
+    "publint": "pnpx publint",
+    "build": "unbuild",
+    "test": "vitest run",
+    "dev": "vitest watch",
+    "clean": "rm -rf dist node_modules"
+  },
+  "devDependencies": {
+    "@poupe/eslint-config": "^0.6.3",
+    "eslint": "^9.26.0",
+    "npm-run-all2": "^8.0.1",
+    "publint": "^0.3.12",
+    "typescript": "~5.8.3",
+    "unbuild": "3.5.0",
+    "vitest": "^3.1.3",
+    "vue-tsc": "~2.2.10"
+  },
+  "engines": {
+    "node": ">= 20",
+    "pnpm": ">= 10"
+  },
+  "packageManager": "pnpm@10.10.0"
+}

--- a/packages/@poupe-css/src/index.ts
+++ b/packages/@poupe-css/src/index.ts
@@ -1,0 +1,19 @@
+export {
+  type CSSValue,
+  type CSSProperties,
+  type CSSPropertiesOptions,
+  stringifyCSSProperties,
+  formatCSSProperties,
+  properties,
+
+  // omit formatCSSValue - only exported for tests
+} from './properties';
+
+export {
+  unsafeKeys,
+  keys,
+  pairs,
+  defaultValidPair,
+
+  kebabCase,
+} from './utils';

--- a/packages/@poupe-css/src/properties.test.ts
+++ b/packages/@poupe-css/src/properties.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type CSSProperties,
+  type CSSPropertiesOptions,
+  formatCSSProperties,
+  formatCSSValue,
+  properties,
+  stringifyCSSProperties,
+} from './properties';
+
+describe('stringifyCSSProperties', () => {
+  it('formats with default options', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      fontSize: '16px',
+      marginTop: 10,
+    };
+    const result = stringifyCSSProperties(cssProps);
+
+    expect(result).toBe('{\n  color: red;\n  font-size: 16px;\n  margin-top: 10\n}');
+  });
+
+  it('formats empty object', () => {
+    const cssProps: CSSProperties = {};
+    const result = stringifyCSSProperties(cssProps);
+
+    expect(result).toBe('{}');
+  });
+
+  it('formats inline when specified', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      fontSize: '16px',
+    };
+    const options: CSSPropertiesOptions = { inline: true };
+    const result = stringifyCSSProperties(cssProps, options);
+
+    expect(result).toBe('{ color: red; font-size: 16px }');
+  });
+
+  it('formats inline when below singleLineThreshold', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+    };
+    const result = stringifyCSSProperties(cssProps); // Default singleLineThreshold is 1
+
+    expect(result).toBe('{ color: red }');
+  });
+
+  it('respects custom singleLineThreshold', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      fontSize: '16px',
+    };
+
+    // With threshold 1 (default), should be multiline
+    const result1 = stringifyCSSProperties(cssProps);
+    expect(result1).toBe('{\n  color: red;\n  font-size: 16px\n}');
+
+    // With threshold 2, should be single line
+    const result2 = stringifyCSSProperties(cssProps, { singleLineThreshold: 2 });
+    expect(result2).toBe('{ color: red; font-size: 16px }');
+
+    // With threshold 3, should still be single line
+    const result3 = stringifyCSSProperties(cssProps, { singleLineThreshold: 3 });
+    expect(result3).toBe('{ color: red; font-size: 16px }');
+  });
+
+  it('uses custom indentation and prefix', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      fontSize: '16px',
+    };
+    const options: CSSPropertiesOptions = {
+      indent: '    ', // 4 spaces
+      prefix: '  ', // 2 spaces
+    };
+    const result = stringifyCSSProperties(cssProps, options);
+
+    expect(result).toBe('{\n      color: red;\n      font-size: 16px\n  }');
+  });
+
+  it('uses custom newLine character', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      fontSize: '16px',
+    };
+    const options: CSSPropertiesOptions = {
+      newLine: '\r\n', // Windows-style line endings
+    };
+    const result = stringifyCSSProperties(cssProps, options);
+
+    expect(result).toBe('{\r\n  color: red;\r\n  font-size: 16px\r\n}');
+  });
+
+  it('combines all custom options correctly', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      fontSize: '16px',
+      margin: [10, 20],
+    };
+    const options: CSSPropertiesOptions = {
+      indent: '  • ', // Bullet point indentation
+      prefix: '» ', // Custom prefix
+      newLine: '\n',
+      inline: false,
+      singleLineThreshold: 2, // multiline
+    };
+    const result = stringifyCSSProperties(cssProps, options);
+
+    expect(result).toBe('{\n»   • color: red;\n»   • font-size: 16px;\n»   • margin: 10, 20\n» }');
+  });
+});
+
+describe('formatCSSProperties', () => {
+  it('formats basic CSS properties', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      fontSize: '16px',
+      marginTop: 10,
+    };
+    const result = formatCSSProperties(cssProps);
+
+    expect(result).toContain('color: red');
+    expect(result).toContain('font-size: 16px');
+    expect(result).toContain('margin-top: 10');
+    expect(result).toHaveLength(3);
+  });
+
+  it('formats CSS properties with array values', () => {
+    const cssProps: CSSProperties = {
+      fontFamily: ['Arial', 'sans-serif'],
+      backgroundImage: ['url(bg.jpg)', 'linear-gradient(red, blue)'],
+    };
+    const result = formatCSSProperties(cssProps);
+
+    expect(result).toContain('font-family: Arial, sans-serif');
+
+    // Check that it contains the background-image property
+    // but be more flexible about the exact format
+    const backgroundImageLine = result.find(line => line.startsWith('background-image:'));
+    expect(backgroundImageLine).toBeDefined();
+    expect(backgroundImageLine).toContain('url(bg.jpg)');
+    expect(backgroundImageLine).toContain('linear-gradient(red, blue)');
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('handles values with spaces', () => {
+    const cssProps: CSSProperties = {
+      fontFamily: 'Times New Roman',
+      gridTemplateAreas: 'header header header main sidebar footer',
+    };
+    const result = formatCSSProperties(cssProps);
+
+    expect(result).toContain('font-family: "Times New Roman"');
+    expect(result).toContain('grid-template-areas: "header header header main sidebar footer"');
+  });
+
+  it('converts camelCase property names to kebab-case', () => {
+    const cssProps: CSSProperties = {
+      backgroundColor: '#fff',
+      borderBottomWidth: '1px',
+      WebkitTransition: 'all 0.2s',
+    };
+    const result = formatCSSProperties(cssProps);
+
+    expect(result).toContain('background-color: #fff');
+    expect(result).toContain('border-bottom-width: 1px');
+    expect(result).toContain('-webkit-transition: "all 0.2s"');
+  });
+
+  it('filters out invalid CSS values', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      margin: '', // Empty string should be filtered out
+      padding: [10, ''], // Array with empty string should be filtered out
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      border: '' as any, // Type assertion to bypass TypeScript
+    };
+    const result = formatCSSProperties(cssProps);
+
+    expect(result).toContain('color: red');
+    expect(result).not.toContain('margin:');
+    expect(result).not.toContain('padding:');
+    expect(result).not.toContain('border:');
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('formatCSSValue', () => {
+  it('formats string values', () => {
+    expect(formatCSSValue('red')).toBe('red');
+    expect(formatCSSValue('#123456')).toBe('#123456');
+  });
+
+  it('formats number values', () => {
+    expect(formatCSSValue(10)).toBe('10');
+    expect(formatCSSValue(0)).toBe('0');
+    expect(formatCSSValue(-5)).toBe('-5');
+  });
+
+  it('formats array values', () => {
+    expect(formatCSSValue(['red', 'blue'])).toBe('red, blue');
+    expect(formatCSSValue([10, 20, 30])).toBe('10, 20, 30');
+    expect(formatCSSValue(['red', 10])).toBe('red, 10');
+  });
+
+  it('quotes string values containing spaces', () => {
+    expect(formatCSSValue('Times New Roman')).toBe('"Times New Roman"');
+    expect(formatCSSValue('10px 20px 30px')).toBe('"10px 20px 30px"');
+  });
+
+  it('quotes array values containing spaces', () => {
+    expect(formatCSSValue(['solid 1px', 'dotted 2px'])).toBe('"solid 1px", "dotted 2px"');
+    expect(formatCSSValue(['Arial', 'Times New Roman'])).toBe('Arial, "Times New Roman"');
+  });
+});
+
+describe('properties generator', () => {
+  it('yields valid CSS properties', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      fontSize: '16px',
+      margin: 10,
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(3);
+    expect(result).toContainEqual(['color', 'red']);
+    expect(result).toContainEqual(['fontSize', '16px']);
+    expect(result).toContainEqual(['margin', 10]);
+  });
+
+  it('filters out invalid CSS values', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      margin: '', // Empty string should be filtered out
+      fontSize: 16,
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(['color', 'red']);
+    expect(result).toContainEqual(['fontSize', 16]);
+    expect(result.map(pair => pair[0])).not.toContain('margin');
+  });
+
+  it('handles array values', () => {
+    const cssProps: CSSProperties = {
+      fontFamily: ['Arial', 'sans-serif'],
+      transform: ['translateX(10px)', 'rotate(45deg)'],
+      margin: [10, 20, 30, 40],
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(3);
+    expect(result).toContainEqual(['fontFamily', ['Arial', 'sans-serif']]);
+    expect(result).toContainEqual(['transform', ['translateX(10px)', 'rotate(45deg)']]);
+    expect(result).toContainEqual(['margin', [10, 20, 30, 40]]);
+  });
+
+  it('filters out arrays with invalid values', () => {
+    const cssProps: CSSProperties = {
+      padding: [10, ''], // Array with some valid, some invalid
+      margin: ['', ''], // Array with all invalid
+      fontFamily: ['Arial', 'sans-serif'], // Valid array
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(1);
+    expect(result).toContainEqual(['fontFamily', ['Arial', 'sans-serif']]);
+    expect(result.map(pair => pair[0])).not.toContain('padding');
+    expect(result.map(pair => pair[0])).not.toContain('margin');
+  });
+
+  it('handles empty objects', () => {
+    const cssProps: CSSProperties = {};
+    const result = [...properties(cssProps)];
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('isValidValue', () => {
+  // Testing the internal isValidValue function through the properties generator behavior
+  it('accepts non-empty strings and numbers', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      opacity: 0.5,
+      zIndex: 100,
+      content: '\'\'',
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(4);
+    expect(result).toContainEqual(['color', 'red']);
+    expect(result).toContainEqual(['opacity', 0.5]);
+    expect(result).toContainEqual(['zIndex', 100]);
+    expect(result).toContainEqual(['content', '\'\'']);
+  });
+
+  it('rejects empty strings', () => {
+    const cssProps: CSSProperties = {
+      color: '',
+      backgroundColor: 'blue',
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(1);
+    expect(result).toContainEqual(['backgroundColor', 'blue']);
+    expect(result.map(pair => pair[0])).not.toContain('color');
+  });
+
+  it('handles array values properly', () => {
+    const cssProps: CSSProperties = {
+      // Valid array
+      margin: [0, 10, 20],
+
+      // Array with invalid (empty string) value
+      padding: [10, ''],
+
+      // Valid string
+      color: 'red',
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(['margin', [0, 10, 20]]);
+    expect(result).toContainEqual(['color', 'red']);
+    expect(result.map(pair => pair[0])).not.toContain('padding');
+  });
+});

--- a/packages/@poupe-css/src/properties.ts
+++ b/packages/@poupe-css/src/properties.ts
@@ -1,0 +1,134 @@
+import {
+  kebabCase,
+  pairs,
+} from './utils';
+
+export type CSSProperties<K extends string = string> = Record<K, CSSValue>;
+export type CSSValue = string | number | (string | number)[];
+
+/**
+ * Configuration options for CSS properties stringification.
+ */
+export type CSSPropertiesOptions = {
+  /** Indentation string, defaults to two spaces. */
+  indent?: string
+  /** Prefix string added before each line, defaults to empty string. */
+  prefix?: string
+  /** New line character, defaults to LF. */
+  newLine?: string
+  /** Whether to format output on a single line, defaults to false. */
+  inline?: boolean
+  /** Maximum number of properties to format on a single line, defaults to 1. */
+  singleLineThreshold?: number
+};
+
+/**
+ * Converts a CSSProperties object into a formatted CSS string representation.
+ *
+ * @param object - The CSSProperties object to stringify.
+ * @param options - Configuration options for string formatting.
+ * @returns A string representing the CSS properties enclosed in curly braces.
+ * @remarks no newLine at the end to aid composition.
+ */
+export function stringifyCSSProperties<K extends string>(
+  object: CSSProperties<K>,
+  options?: CSSPropertiesOptions,
+): string {
+  const {
+    indent = '  ',
+    prefix = '',
+    newLine = '\n',
+    inline = false,
+    singleLineThreshold = 1,
+  } = options || {};
+
+  const lines = formatCSSProperties(object);
+
+  // Handle empty blocks with a simple format
+  if (lines.length === 0) {
+    return '{}';
+  }
+
+  // Handle inline mode or when property count is below threshold
+  if (inline || lines.length <= singleLineThreshold) {
+    return `{ ${lines.join('; ')} }`;
+  }
+
+  // Standard multiline format
+  return `{${newLine}${prefix}${indent}${lines.join(`;${newLine}${prefix}${indent}`)}${newLine}${prefix}}`;
+}
+
+/**
+ * Formats a CSSProperties object into an array of CSS property strings.
+ *
+ * @param object - The CSSProperties object to format.
+ * @returns An array of strings, where each string is a CSS property in the format "key: value;".
+ */
+export function formatCSSProperties<K extends string>(object: CSSProperties<K>): string[] {
+  const lines: string[] = [];
+  for (const [key, value] of properties(object)) {
+    const kebabKey = kebabCase(key);
+    const formattedValue = formatCSSValue(value);
+    // don't bother with deduplication
+    lines.push(`${kebabKey}: ${formattedValue}`);
+  }
+  return lines;
+}
+
+/**
+ * Formats a CSS value into a string.
+ * If the value is an array, it joins the elements with a comma and a space.
+ * If the value is a string containing spaces, it encloses the string in double quotes.
+ *
+ * @param value - The CSS value to format.
+ * @returns The formatted CSS value as a string.
+ */
+export function formatCSSValue(value: CSSValue): string {
+  if (Array.isArray(value)) {
+    return value.map(v => quoted(v)).join(', ');
+  }
+  return quoted(value);
+}
+
+/**
+ * Encloses a CSS value in double quotes if it is a string containing spaces.
+ * Otherwise, converts the value to a string.
+ *
+ * @param v - The CSS value to process.
+ * @returns The processed CSS value as a string.
+ */
+function quoted(v: CSSValue): string {
+  if (typeof v === 'string' && v.includes(' ')) {
+    return `"${v}"`;
+  }
+  return String(v);
+}
+
+/**
+ * Generates a sequence of valid CSS property key-value pairs from a CSSProperties object.
+ *
+
+ * @param object - The object containing CSS properties.
+ * @returns A generator of valid key-value CSS property pairs.
+ * @remarks Filters out invalid or empty CSS property values, returning only valid entries.
+ */
+export function* properties<K extends string>(object: CSSProperties<K>): Generator<[K, CSSValue]> {
+  for (const [key, value] of pairs(object)) {
+    if (Array.isArray(value) ? value.every(v => isValidValue(v)) : isValidValue(value)) {
+      yield [key, value as CSSValue];
+    }
+  }
+}
+
+/**
+ * Checks if a CSS value is valid.
+ * A value is considered valid if it is a non-empty string or a number.
+ *
+ * @param value - The value to check.
+ * @returns True if the value is valid, false otherwise.
+ */
+function isValidValue(value: unknown): boolean {
+  if (typeof value === 'string')
+    return value !== '';
+  return typeof value === 'number';
+}

--- a/packages/@poupe-css/src/utils.test.ts
+++ b/packages/@poupe-css/src/utils.test.ts
@@ -1,0 +1,162 @@
+/* eslint-disable unicorn/no-null */
+/* eslint-disable unicorn/consistent-function-scoping */
+import { describe, it, expect } from 'vitest';
+import { defaultValidPair, pairs, kebabCase, unsafeKeys, keys } from './utils';
+
+describe('defaultValidPair', () => {
+  it('returns true for valid key-value pairs', () => {
+    expect(defaultValidPair('valid', 'value')).toBe(true);
+    expect(defaultValidPair('valid', 0)).toBe(true);
+    expect(defaultValidPair('valid', false)).toBe(true);
+    expect(defaultValidPair('valid', {})).toBe(true);
+    expect(defaultValidPair('valid', [])).toBe(true);
+  });
+
+  it('returns false for null or undefined values', () => {
+    expect(defaultValidPair('key', null)).toBe(false);
+    expect(defaultValidPair('key', undefined)).toBe(false);
+  });
+
+  it('returns false if key contains spaces', () => {
+    expect(defaultValidPair('invalid key', 'value')).toBe(false);
+  });
+
+  it('returns false if key starts with underscore', () => {
+    expect(defaultValidPair('_hidden', 'value')).toBe(false);
+  });
+});
+
+describe('pairs', () => {
+  it('yields valid key-value pairs', () => {
+    const object = {
+      'valid1': 'value1',
+      'valid2': 'value2',
+      '_hidden': 'hidden',
+      'invalid space': 'space',
+
+      'empty': null,
+    };
+
+    const result = [...pairs(object)];
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(['valid1', 'value1']);
+    expect(result).toContainEqual(['valid2', 'value2']);
+  });
+
+  it('respects custom validation function', () => {
+    const object = {
+      valid: 'value',
+      _prefixed: 'still-valid-with-custom-validator',
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const customValidator = (key: string, _value: unknown) =>
+      key !== 'invalid';
+
+    const result = [...pairs(object, customValidator)];
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(['valid', 'value']);
+    expect(result).toContainEqual(['_prefixed', 'still-valid-with-custom-validator']);
+  });
+
+  it('handles empty objects', () => {
+    const object = {};
+    const result = [...pairs(object)];
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles objects with all invalid entries', () => {
+    const object = {
+      '_hidden1': 'value1',
+      '_hidden2': 'value2',
+      'invalid key': 'value3',
+
+      'null1': null,
+      'undefined1': undefined,
+    };
+    const result = [...pairs(object)];
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('kebabCase', () => {
+  it('converts camelCase to kebab-case', () => {
+    expect(kebabCase('camelCase')).toBe('camel-case');
+    expect(kebabCase('multipleWords')).toBe('multiple-words');
+  });
+
+  it('converts PascalCase to kebab-case', () => {
+    expect(kebabCase('PascalCase')).toBe('pascal-case');
+    expect(kebabCase('HTMLElement')).toBe('html-element');
+  });
+
+  it('converts snake_case to kebab-case', () => {
+    expect(kebabCase('snake_case')).toBe('snake-case');
+    expect(kebabCase('multiple_words_here')).toBe('multiple-words-here');
+  });
+
+  it('handles spaces correctly', () => {
+    expect(kebabCase('with spaces')).toBe('with-spaces');
+    expect(kebabCase('  multiple  spaces  ')).toBe('multiple-spaces');
+  });
+
+  it('handles multiple uppercase letters correctly', () => {
+    expect(kebabCase('XMLHttpRequest')).toBe('xml-http-request');
+    expect(kebabCase('BGColor')).toBe('bg-color');
+  });
+
+  it('adds leading hyphen to vendor prefixes', () => {
+    expect(kebabCase('WebkitTransition')).toBe('-webkit-transition');
+    expect(kebabCase('MozBorderRadius')).toBe('-moz-border-radius');
+    expect(kebabCase('MsFlexbox')).toBe('-ms-flexbox');
+    expect(kebabCase('OAnimation')).toBe('-o-animation');
+    expect(kebabCase('KhtmlUserSelect')).toBe('-khtml-user-select');
+  });
+
+  it('handles complex vendor prefixed properties', () => {
+    expect(kebabCase('WebkitTapHighlightColor')).toBe('-webkit-tap-highlight-color');
+    expect(kebabCase('MozOsxFontSmoothing')).toBe('-moz-osx-font-smoothing');
+    expect(kebabCase('MsImeAlign')).toBe('-ms-ime-align');
+  });
+});
+
+describe('unsafeKeys', () => {
+  it('returns keys from an object', () => {
+    const object = { a: 1, b: 2, c: 3 };
+    expect(unsafeKeys(object)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns empty array for empty object', () => {
+    const object = {};
+    expect(unsafeKeys(object)).toEqual([]);
+  });
+});
+
+describe('keys', () => {
+  it('yields all keys from an object', () => {
+    const object = { a: 1, b: 2, c: 3 };
+    const result = [...keys(object)];
+    expect(result).toEqual(['a', 'b', 'c']);
+  });
+
+  it('yields empty array for empty object', () => {
+    const object = {};
+    const result = [...keys(object)];
+    expect(result).toEqual([]);
+  });
+
+  it('respects validation function', () => {
+    const object = { a: 1, b: 2, c: 3 };
+    const valid = (key: string) => key !== 'b';
+    const result = [...keys(object, valid)];
+    expect(result).toEqual(['a', 'c']);
+  });
+
+  it('skips non-own properties', () => {
+    const proto = { inherited: true };
+    const object = Object.create(proto);
+    object.own = true;
+    const result = [...keys(object)];
+    expect(result).toEqual(['own']);
+  });
+});

--- a/packages/@poupe-css/src/utils.ts
+++ b/packages/@poupe-css/src/utils.ts
@@ -1,0 +1,103 @@
+/**
+ * A type-safe wrapper around Object.keys that preserves the object's key types.
+ *
+ * @returns a typed array of keys of the object
+ */
+export const unsafeKeys = Object.keys as <T>(object: T) => Array<keyof T>;
+
+/**
+ * A generator function that yields keys of an object that pass an optional validation function.
+ *
+ * Iterates through all own properties of the given object and yields
+ * each key that passes the optional validation function.
+ *
+ * @param object - The object to iterate over
+ * @param valid - Optional validation function that determines which keys to yield
+ * @returns A generator of valid keys from the object
+ */
+export function* keys<T, K extends keyof T>(object: T, valid?: (key: keyof T) => boolean): Generator<K> {
+  for (const key of unsafeKeys(object)) {
+    if (typeof key === 'string' && Object.prototype.hasOwnProperty.call(object, key) && (valid?.(key) ?? true)) {
+      yield key as K;
+    }
+  }
+}
+
+/**
+ * Validates if a key-value pair meets default criteria.
+ *
+ * A key-value pair is considered valid when:
+ * - The value is neither null nor undefined
+ * - The key doesn't contain spaces
+ * - The key doesn't start with an underscore (_)
+ *
+ * @param key - The key to validate
+ * @param value - The value to validate
+ * @returns true if the key-value pair is valid, false otherwise
+ *
+ */
+export function defaultValidPair<K extends string, T = unknown>(key: K, value: T): boolean {
+  return value !== null
+    && value !== undefined
+    && !key.includes(' ')
+    && !key.startsWith('_');
+}
+
+/**
+ * A generator function that yields valid key-value pairs from an object.
+ *
+ * Iterates through all own properties of the given object and yields
+ * each key-value pair that passes the validation function.
+ *
+ * @param object - The object to iterate over
+ * @param valid - Optional validation function that determines which key-value pairs to yield
+ * @returns A generator of valid key-value pairs from the object
+ */
+export function* pairs<K extends string = string, T1 = unknown, T2 = unknown>(
+  object: Record<K, T1>,
+  valid?: (k: K, v: T1) => boolean,
+): Generator<[K, T2]> {
+  for (const key of keys(object)) {
+    const value = object[key];
+    if (valid?.(key, value) ?? defaultValidPair(key, value))
+      yield [key, value as unknown as T2];
+  }
+}
+
+/*
+ * Converts a given string to kebab-case.
+ *
+ * Transforms various string formats (camelCase, PascalCase, snake_case)
+ * into a lowercase string with words separated by hyphens.
+ * Adds leading hyphen to recognized vendor prefixes.
+ *
+ * @param s - The input string to convert
+ * @returns A kebab-case representation of the input string
+ *
+ * @example
+ * kebabCase('XMLHttpRequest') // returns 'xml-http-request'
+ * kebabCase('camelCase') // returns 'camel-case'
+ * kebabCase('snake_case') // returns 'snake-case'
+ * kebabCase('WebkitTransition') // returns '-webkit-transition'
+ */
+export function kebabCase(s: string): string {
+  // Apply standard kebab-case transformations
+  const kebabbed = s
+    .trim()
+    // handle multiple uppercase letters (e.g., XMLHttpRequest -> xml-http-request)
+    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    // handle camelCase
+    .replaceAll(/([a-z])([A-Z])/g, '$1-$2')
+    // handle snakeCase
+    .replaceAll(/[\s_]+/g, '-')
+    .toLowerCase();
+
+  // Check for vendor prefixes using a regex and add leading hyphen if needed
+  if (vendorPrefixPattern.test(kebabbed)) {
+    return `-${kebabbed}`;
+  }
+
+  return kebabbed;
+}
+
+const vendorPrefixPattern = /^(webkit|moz|ms|o|khtml)-/;

--- a/packages/@poupe-css/tsconfig.json
+++ b/packages/@poupe-css/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": [
+    "src",
+    "build.config.ts",
+    "vitest.config.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/@poupe-css/vitest.config.ts
+++ b/packages/@poupe-css/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node', // or 'jsdom' if your tests ever require a DOM
+    globals: true, // Optional: enables global APIs like describe, it, expect
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['text', 'json-summary', 'json', 'html'],
+      include: ['src/**/*.ts'], // Adjust based on your source code location
+      exclude: [
+        // Add patterns for files/directories to exclude from coverage
+        'src/index.ts', // Often entry points don't need coverage
+        '**/*.spec.ts',
+        '**/*.test.ts',
+        '**/__tests__/**',
+        '**/dist/**',
+      ],
+    },
+  },
+  // If you use path aliases in your project (e.g., in tsconfig.json),
+  // you might need to configure them here as well.
+  // resolve: {
+  //   alias: {
+  //     // Example: '@': path.resolve(__dirname, './src'),
+  //   },
+  // },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,33 @@ importers:
         specifier: ^0.0.43
         version: 0.0.43
 
+  packages/@poupe-css:
+    devDependencies:
+      '@poupe/eslint-config':
+        specifier: ^0.6.3
+        version: 0.6.3(jiti@2.4.2)(typescript@5.8.3)(vue-eslint-parser@10.1.1(eslint@9.26.0(jiti@2.4.2)))
+      eslint:
+        specifier: ^9.26.0
+        version: 9.26.0(jiti@2.4.2)
+      npm-run-all2:
+        specifier: ^8.0.1
+        version: 8.0.1
+      publint:
+        specifier: ^0.3.12
+        version: 0.3.12
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      unbuild:
+        specifier: 3.5.0
+        version: 3.5.0(typescript@5.8.3)(vue-sfc-transformer@0.1.10(esbuild@0.25.3)(vue@3.5.13(typescript@5.8.3)))(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))
+      vitest:
+        specifier: ^3.1.3
+        version: 3.1.3(@types/node@22.15.17)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vue-tsc:
+        specifier: ~2.2.10
+        version: 2.2.10(typescript@5.8.3)
+
   packages/@poupe-nuxt:
     dependencies:
       '@nuxt/icon':

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,5 @@
+import { defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace([
+  './packages/*/vitest.config.ts',
+]);


### PR DESCRIPTION
and add top-level vitest.workspace.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `@poupe/css` TypeScript utility library for CSS property manipulation and formatting.
  - Provides functions for converting CSS property objects to formatted CSS strings and arrays, with customizable formatting options.
  - Includes utilities for key/value iteration, kebab-case conversion, and type-safe object handling.

- **Documentation**
  - Added comprehensive README with installation instructions, API documentation, and usage examples.

- **Tests**
  - Added extensive tests covering formatting utilities and helper functions to ensure correctness and robustness.

- **Chores**
  - Added build, test, and TypeScript configuration files for streamlined development and publishing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->