### PR TITLE
feat(poupe-css): properties() skip empty arrays and formatCSSProperties deduplication

### DIFF
--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -83,7 +83,8 @@ const customCSS = stringifyCSSProperties(styles, {
 ```
 
 #### `formatCSSProperties<K extends string>(object: CSSProperties<K>): string[]`
-Formats a CSS properties object into an array of CSS property strings.
+Formats a CSS properties object into an array of CSS property strings. Automatically handles deduplication of
+properties, where later declarations override earlier ones while preserving the original insertion order.
 
 ```typescript
 import { formatCSSProperties } from '@poupe/css';
@@ -91,13 +92,15 @@ import { formatCSSProperties } from '@poupe/css';
 const styles = {
   fontSize: '16px',
   backgroundColor: 'red',
-  margin: [10, '20px', '30px', '40px']
+  margin: [10, '20px', '30px', '40px'],
+  // Later declarations override earlier ones:
+  backgroundColor: 'blue'
 };
 
 const cssLines = formatCSSProperties(styles);
 // [
 //   "font-size: 16px",
-//   "background-color: red",
+//   "background-color: blue", // Note: red was overridden by blue
 //   "margin: 10, 20px, 30px, 40px"
 // ]
 ```

--- a/packages/@poupe-css/package.json
+++ b/packages/@poupe-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/css",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "A TypeScript utility library for CSS property manipulation, formatting, and CSS-in-JS operations",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-css/src/properties.test.ts
+++ b/packages/@poupe-css/src/properties.test.ts
@@ -186,6 +186,58 @@ describe('formatCSSProperties', () => {
     expect(result).not.toContain('border:');
     expect(result).toHaveLength(1);
   });
+
+  it('deduplicates identical property names', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      margin: '10px',
+      Color: 'blue', // Duplicate property name
+    };
+    const result = formatCSSProperties(cssProps);
+
+    expect(result).toContain('color: blue');
+    expect(result).not.toContain('color: red');
+    expect(result).toContain('margin: 10px');
+    expect(result).toHaveLength(2);
+  });
+
+  it('deduplicates kebab-case equivalent property names', () => {
+    const cssProps: CSSProperties = {
+      'background-color': 'red',
+      'backgroundColor': 'blue',
+    };
+    const result = formatCSSProperties(cssProps);
+
+    expect(result).toContain('background-color: blue');
+    expect(result).not.toContain('background-color: red');
+    expect(result).toHaveLength(1);
+  });
+
+  it('preserves order of first occurrence while deduplicating', () => {
+    const cssProps: CSSProperties = {
+      color: 'red',
+      margin: '10px',
+      padding: '5px',
+      Color: 'blue', // Duplicate that will replace the first color
+      fontSize: '16px',
+      Margin: '20px', // Duplicate that will replace the first margin
+    };
+    const result = formatCSSProperties(cssProps);
+
+    // Check results contain updated values
+    expect(result).toContain('color: blue');
+    expect(result).toContain('margin: 20px');
+    expect(result).toContain('padding: 5px');
+    expect(result).toContain('font-size: 16px');
+
+    // Check property order matches first occurrence order
+    expect(result[0]).toBe('color: blue');
+    expect(result[1]).toBe('margin: 20px');
+    expect(result[2]).toBe('padding: 5px');
+    expect(result[3]).toBe('font-size: 16px');
+
+    expect(result).toHaveLength(4);
+  });
 });
 
 describe('formatCSSValue', () => {

--- a/packages/@poupe-css/src/properties.test.ts
+++ b/packages/@poupe-css/src/properties.test.ts
@@ -283,6 +283,22 @@ describe('properties generator', () => {
     const result = [...properties(cssProps)];
     expect(result).toHaveLength(0);
   });
+
+  it('rejects empty arrays', () => {
+    const cssProps: CSSProperties = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      margin: [] as any, // Type assertion to bypass TypeScript
+      padding: [10, 20], // Valid array
+      color: 'red', // Valid string
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(['padding', [10, 20]]);
+    expect(result).toContainEqual(['color', 'red']);
+    expect(result.map(pair => pair[0])).not.toContain('margin');
+  });
 });
 
 describe('isValidValue', () => {
@@ -335,5 +351,19 @@ describe('isValidValue', () => {
     expect(result).toContainEqual(['margin', [0, 10, 20]]);
     expect(result).toContainEqual(['color', 'red']);
     expect(result.map(pair => pair[0])).not.toContain('padding');
+  });
+
+  it('rejects empty arrays', () => {
+    const cssProps: CSSProperties = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      margin: [] as any,
+      color: 'blue',
+    };
+
+    const result = [...properties(cssProps)];
+
+    expect(result).toHaveLength(1);
+    expect(result).toContainEqual(['color', 'blue']);
+    expect(result.map(pair => pair[0])).not.toContain('margin');
   });
 });

--- a/packages/@poupe-css/src/properties.ts
+++ b/packages/@poupe-css/src/properties.ts
@@ -107,14 +107,13 @@ function quoted(v: CSSValue): string {
 /**
  * Generates a sequence of valid CSS property key-value pairs from a CSSProperties object.
  *
-
  * @param object - The object containing CSS properties.
  * @returns A generator of valid key-value CSS property pairs.
  * @remarks Filters out invalid or empty CSS property values, returning only valid entries.
  */
 export function* properties<K extends string>(object: CSSProperties<K>): Generator<[K, CSSValue]> {
   for (const [key, value] of pairs(object)) {
-    if (Array.isArray(value) ? value.every(v => isValidValue(v)) : isValidValue(value)) {
+    if (Array.isArray(value) ? (value.length > 0 && value.every(v => isValidValue(v))) : isValidValue(value)) {
       yield [key, value as CSSValue];
     }
   }

--- a/packages/@poupe-css/src/properties.ts
+++ b/packages/@poupe-css/src/properties.ts
@@ -65,12 +65,16 @@ export function stringifyCSSProperties<K extends string>(
  * @returns An array of strings, where each string is a CSS property in the format "key: value;".
  */
 export function formatCSSProperties<K extends string>(object: CSSProperties<K>): string[] {
-  const lines: string[] = [];
+  const propertyMap = new Map<string, string>();
   for (const [key, value] of properties(object)) {
     const kebabKey = kebabCase(key);
     const formattedValue = formatCSSValue(value);
-    // don't bother with deduplication
-    lines.push(`${kebabKey}: ${formattedValue}`);
+    propertyMap.set(kebabKey, formattedValue);
+  }
+
+  const lines: string[] = [];
+  for (const [key, value] of propertyMap) {
+    lines.push(`${key}: ${value}`);
   }
   return lines;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify that duplicate CSS properties are automatically deduplicated, with later declarations overriding earlier ones, and updated examples to reflect this behavior.

- **Bug Fixes**
  - Improved handling of CSS property deduplication, ensuring that later property values override earlier ones, regardless of case or naming style.
  - Enhanced validation to exclude empty arrays from being processed as valid CSS property values.

- **Tests**
  - Added tests to verify deduplication of CSS properties and stricter validation for empty arrays.

- **Chores**
  - Bumped package version from 0.1.0 to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->