### PR TITLE
feat(config): renovate: improve grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
         "@nuxt/**",
         "@nuxtjs/**",
         "nuxt",
+        "nuxi",
         "/^nuxt-.*$/"
       ]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,12 @@
         "nuxi",
         "/^nuxt-.*$/"
       ]
+    }, {
+      "groupName": "eslint dependencies",
+      "groupSlug": "eslint",
+      "matchPackageNames": [
+        "/eslint/"
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
add `nuxi` to `nuxt`, and group all `*eslint*` packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package grouping rules for automated dependency updates to include "nuxi" in the Nuxt.js group and added a new group for all ESLint-related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->