### PR TITLE
feat(poupe-color): initial release of @poupe/color

### DIFF
--- a/packages/@poupe-color/.editorconfig
+++ b/packages/@poupe-color/.editorconfig
@@ -1,0 +1,1 @@
+root = false

--- a/packages/@poupe-color/README.md
+++ b/packages/@poupe-color/README.md
@@ -1,0 +1,67 @@
+# @poupe/color
+
+[![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@poupe/color)
+[![npm version](https://img.shields.io/npm/v/@poupe/color.svg)](https://www.npmjs.com/package/@poupe/color)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENCE.txt)
+
+HCT/HCL color-space utils
+
+## D3 Color Utilities
+
+The `@poupe/color` package includes a D3 subpackage that provides color conversion and manipulation
+capabilities built on top of the powerful [d3-color](https://github.com/d3/d3-color) library.
+
+### Features
+
+- **Versatile color conversion**: Convert between different color formats including CSS strings, ARGB numbers,
+  and various color space objects
+- **Multiple color spaces**: Work with RGB, HSL, HCL, Lab, HSV, and HCT color spaces
+- **Type checking**: Easily verify color object types with helper functions
+- **Seamless d3-color integration**: Direct access to d3-color's core functionality with enhanced capabilities
+
+### Color Functions
+
+```typescript
+// Convert from any color format
+const myColor = color('#ff0000');            // From CSS string
+const myColor = color(0xFFFF0000);           // From ARGB number
+const myColor = color({ h: 0, c: 100, l: 50 }); // From HCL object
+const myColor = color({ h: 0, s: 1, v: 1 });    // From HSV object
+const myColor = color({ h: 0, c: 50, t: 60 });  // From HCT object
+
+// Create colors in specific spaces
+const myRgb = rgb(255, 0, 0);
+const myHsl = hsl(0, 1, 0.5);
+const myHcl = hcl(0, 100, 50);
+const myLab = lab(50, 80, 67);
+
+// Type checking
+if (isRGB(myColor)) {
+  // Work with RGB properties
+}
+```
+
+### Supported Color Spaces
+
+- **RGB**: Red, Green, Blue - standard digital color representation
+- **HSL**: Hue, Saturation, Lightness - intuitive color selection
+- **HCL**: Hue, Chroma, Luminance - perceptually uniform color space
+- **Lab**: CIE L*a*b* - device-independent, perceptually uniform color space
+- **HSV**: Hue, Saturation, Value - alternative to HSL (converted to HSL when using `color()`)
+- **HCT**: Hue, Chroma, Tone - Material Design 3 color space (converted to HCL when using `color()`)
+
+Use these utilities for building color palettes, theming systems, color conversions, and more complex
+color manipulations in your Poupe UI projects.
+
+
+## Integration with Poupe Ecosystem
+
+- [@poupe/css](../@poupe-css) - CSS-in-JS utilities
+- [@poupe/theme-builder](../@poupe-theme-builder) - Design tokens generation
+- [@poupe/tailwindcss](../@poupe-tailwindcss) - TailwindCSS integration
+- [@poupe/vue](../@poupe-vue) - Vue components library
+- [@poupe/nuxt](../@poupe-nuxt) - Nuxt integration
+
+## License
+
+MIT licensed.

--- a/packages/@poupe-color/build.config.ts
+++ b/packages/@poupe-color/build.config.ts
@@ -1,0 +1,11 @@
+import { defineBuildConfig } from 'unbuild';
+
+export default defineBuildConfig({
+  entries: [
+    { input: 'src/index', name: 'index' },
+    { input: 'src/d3/index', name: 'd3' },
+    { input: 'src/utils/index', name: 'utils' },
+  ],
+  declaration: true,
+  sourcemap: true,
+});

--- a/packages/@poupe-color/package.json
+++ b/packages/@poupe-color/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@poupe/color",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "A HCT/HCL color-space utility library powered by D3.js",
+  "author": "Alejandro Mery <amery@apptly.co>",
+  "license": "MIT",
+  "keywords": [
+    "d3",
+    "hct",
+    "hcl",
+    "material-design",
+    "poupe",
+    "typescript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/poupe-ui/poupe.git",
+    "directory": "packages/@poupe-color"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./d3": {
+      "types": "./dist/d3.d.mts",
+      "default": "./dist/d3.mjs"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.mts",
+      "default": "./dist/utils.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepack": "run-s lint type-check test build publint",
+    "dev:prepare": "unbuild --stub",
+    "type-check": "tsc --noEmit",
+    "lint": "env DEBUG=eslint:eslint eslint --fix .",
+    "publint": "pnpx publint",
+    "build": "unbuild",
+    "test": "vitest run",
+    "dev": "vitest watch",
+    "clean": "rm -rf dist node_modules"
+  },
+  "dependencies": {
+    "d3-color": "^3.1.0"
+  },
+  "devDependencies": {
+    "@poupe/eslint-config": "^0.6.3",
+    "@types/d3-color": "^3.1.3",
+    "@types/node": "^20.17.46",
+    "eslint": "^9.26.0",
+    "npm-run-all2": "^8.0.1",
+    "publint": "^0.3.12",
+    "typescript": "~5.8.3",
+    "unbuild": "3.5.0",
+    "vitest": "^3.1.3",
+    "vue-tsc": "~2.2.10"
+  },
+  "engines": {
+    "node": ">= 20.19.1",
+    "pnpm": ">= 10.10.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
+}

--- a/packages/@poupe-color/src/core/__tests__/utils.test.ts
+++ b/packages/@poupe-color/src/core/__tests__/utils.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  uint32,
+  uint8,
+  alphaFromARGB,
+  redFromARGB,
+  greenFromARGB,
+  blueFromARGB,
+  rgbaFromARGB,
+} from '../utils';
+
+describe('Color utilities', () => {
+  describe('uint32', () => {
+    it('converts numbers to unsigned 32-bit integers', () => {
+      expect(uint32(0)).toBe(0);
+      expect(uint32(255)).toBe(255);
+      expect(uint32(-1)).toBe(4_294_967_295); // 2^32 - 1
+      expect(uint32(4_294_967_295)).toBe(4_294_967_295);
+      expect(uint32(4_294_967_296)).toBe(0); // Overflow to 0
+    });
+  });
+
+  describe('uint8', () => {
+    it('converts numbers to unsigned 8-bit integers', () => {
+      expect(uint8(0)).toBe(0);
+      expect(uint8(255)).toBe(255);
+      expect(uint8(256)).toBe(0); // Overflow to 0
+      expect(uint8(-1)).toBe(255); // 2^8 - 1
+      expect(uint8(300)).toBe(44); // 300 % 256 = 44
+    });
+  });
+
+  describe('ARGB extraction functions', () => {
+    // Common test values
+    const opaqueRed = 0xFF_00_00_FF; // Alpha=255 (fully opaque), R=0, G=0, B=255 (blue)
+    const semiTransparentGreen = 0x80_00_FF_00; // Alpha=128 (semi-transparent), R=0, G=255, B=0 (green)
+    const fullyTransparentRed = 0x00_FF_00_00; // Alpha=0 (fully transparent), R=255, G=0, B=0 (red)
+
+    describe('alphaFromARGB', () => {
+      it('extracts alpha values correctly', () => {
+        expect(alphaFromARGB(opaqueRed)).toBe(1);
+        expect(alphaFromARGB(semiTransparentGreen)).toBe(128 / 255);
+        expect(alphaFromARGB(fullyTransparentRed)).toBe(0);
+      });
+    });
+
+    describe('redFromARGB', () => {
+      it('extracts red component correctly', () => {
+        expect(redFromARGB(opaqueRed)).toBe(0);
+        expect(redFromARGB(semiTransparentGreen)).toBe(0);
+        expect(redFromARGB(fullyTransparentRed)).toBe(255);
+        expect(redFromARGB(0xFF_AB_12_34)).toBe(0xAB);
+      });
+    });
+
+    describe('greenFromARGB', () => {
+      it('extracts green component correctly', () => {
+        expect(greenFromARGB(opaqueRed)).toBe(0);
+        expect(greenFromARGB(semiTransparentGreen)).toBe(255);
+        expect(greenFromARGB(fullyTransparentRed)).toBe(0);
+        expect(greenFromARGB(0xFF_AB_CD_34)).toBe(0xCD);
+      });
+    });
+
+    describe('blueFromARGB', () => {
+      it('extracts blue component correctly', () => {
+        expect(blueFromARGB(opaqueRed)).toBe(255);
+        expect(blueFromARGB(semiTransparentGreen)).toBe(0);
+        expect(blueFromARGB(fullyTransparentRed)).toBe(0);
+        expect(blueFromARGB(0xFF_AB_CD_EF)).toBe(0xEF);
+      });
+    });
+
+    describe('rgbaFromARGB', () => {
+      it('converts ARGB to RGBColor with opacity when needed', () => {
+        // Test with full opacity
+        expect(rgbaFromARGB(opaqueRed)).toEqual({
+          r: 0,
+          g: 0,
+          b: 255,
+        });
+
+        // Test with partial opacity
+        expect(rgbaFromARGB(semiTransparentGreen)).toEqual({
+          r: 0,
+          g: 255,
+          b: 0,
+          opacity: 128 / 255,
+        });
+
+        // Test with forced opacity=1
+        expect(rgbaFromARGB(opaqueRed, true)).toEqual({
+          r: 0,
+          g: 0,
+          b: 255,
+          opacity: 1,
+        });
+
+        // Test with zero alpha (defaults to 1)
+        expect(rgbaFromARGB(fullyTransparentRed)).toEqual({
+          r: 255,
+          g: 0,
+          b: 0,
+          opacity: 0,
+        });
+      });
+    });
+  });
+});

--- a/packages/@poupe-color/src/core/types.ts
+++ b/packages/@poupe-color/src/core/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Defines type definitions for various color models used throughout the Poupe UI color system.
+ * Each color type can include an optional opacity value.
+ */
+
+/**
+ * RGB color model - represents colors in terms of red, green, and blue components.
+ */
+export type RGBColor = {
+  /** Red component (0-255) */
+  r: number
+  /** Green component (0-255) */
+  g: number
+  /** Blue component (0-255) */
+  b: number
+  /** Optional transparency value (0-1) */
+  opacity?: number
+};
+
+/**
+ * LAB color model - device-independent color model that represents colors
+ * using lightness (L) and two color-opponent dimensions (a, b).
+ */
+export type LabColor = {
+  /** Lightness component (0-100) */
+  l: number
+  /** Green-red component (typically -128 to +127) */
+  a: number
+  /** Blue-yellow component (typically -128 to +127) */
+  b: number
+  /** Optional transparency value (0-1) */
+  opacity?: number
+};
+
+/**
+ * HCL color model - represents colors in terms of hue, chroma, and luminance.
+ * Similar to HSL but provides better perceptual uniformity.
+ */
+export type HCLColor = {
+  /** Hue component in degrees (0-360) */
+  h: number
+  /** Chroma component (saturation-like) */
+  c: number
+  /** Luminance component */
+  l: number
+  /** Optional transparency value (0-1) */
+  opacity?: number
+};
+
+/**
+ * HCT color model - represents colors in terms of hue, chroma, and tone.
+ * Used in Material Design's color system for accessibility and consistency.
+ */
+export type HCTColor = {
+  /** Hue component in degrees (0-360) */
+  h: number
+  /** Chroma component (colorfulness) */
+  c: number
+  /** Tone component (lightness perception) */
+  t: number
+  /** Optional transparency value (0-1) */
+  opacity?: number
+};
+
+/**
+ * HSL color model - represents colors in terms of hue, saturation, and lightness.
+ * A cylindrical representation of the RGB color model.
+ */
+export type HSLColor = {
+  /** Hue component in degrees (0-360) */
+  h: number
+  /** Saturation component (0-100%) */
+  s: number
+  /** Lightness component (0-100%) */
+  l: number
+  /** Optional transparency value (0-1) */
+  opacity?: number
+};
+
+/**
+ * HSV color model - represents colors in terms of hue, saturation, and value (brightness).
+ * Also known as HSB (hue, saturation, brightness).
+ */
+export type HSVColor = {
+  /** Hue component in degrees (0-360) */
+  h: number
+  /** Saturation component (0-100%) */
+  s: number
+  /** Value/brightness component (0-100%) */
+  v: number
+  /** Optional transparency value (0-1) */
+  opacity?: number
+};
+
+/**
+ * Union type for all supported object-based color representations.
+ * Used for type checking and consistent handling of different color models.
+ */
+export type ObjectColor = RGBColor | LabColor | HCLColor | HCTColor | HSLColor | HSVColor;
+
+/**
+ * Union type representing any valid color input format.
+ * Can be a string (e.g., hex, named color), number (e.g., RGB integer),
+ * or any of the supported object-based color models.
+ */
+export type AnyColor = string | number | ObjectColor;

--- a/packages/@poupe-color/src/core/utils.ts
+++ b/packages/@poupe-color/src/core/utils.ts
@@ -1,0 +1,58 @@
+import {
+  type RGBColor,
+} from './types';
+
+/** Converts a number to an unsigned 32-bit integer */
+export const uint32 = (n: number) => n >>> 0;
+
+/** Converts a number to an unsigned 8-bit integer */
+export const uint8 = (n: number) => (n >>> 0) & 0xFF;
+
+/**
+ * Extracts the alpha (opacity) value from an ARGB color value.
+ *
+ * @param argb - The color value in ARGB format (32-bit integer)
+ */
+export const alphaFromARGB = (argb: number): number => uint8(argb >>> 24) / 255;
+
+/**
+ * Extracts the red color component from an ARGB color value.
+ *
+ * @param argb - The color value in ARGB format (32-bit integer)
+ * @returns The red color component value between 0 and 255
+ */
+export const redFromARGB = (argb: number): number => uint8(argb >>> 16);
+
+/**
+ * Extracts the green color component from an ARGB color value.
+ *
+ * @param argb - The color value in ARGB format (32-bit integer)
+ * @returns The green color component value between 0 and 255
+ */
+export const greenFromARGB = (argb: number): number => uint8(argb >>> 8);
+
+/**
+ * Extracts the blue color component from an ARGB color value.
+ *
+ * @param argb - The color value in ARGB format (32-bit integer)
+ * @returns The blue color component value between 0 and 255
+ */
+export const blueFromARGB = (argb: number): number => uint8(argb);
+
+/**
+ * Converts an ARGB color value to an RGBColor object with optional opacity.
+ *
+ * @param argb - The color value in ARGB format (32-bit integer)
+ * @param opacityOne - Optional flag to force opacity to 1 or include opacity only if less than 1
+ * @returns An RGBColor object with red, green, blue, and optional opacity values
+ */
+export function rgbaFromARGB(argb: number, opacityOne?: boolean): RGBColor {
+  const a = alphaFromARGB(argb);
+
+  return {
+    r: redFromARGB(argb),
+    g: greenFromARGB(argb),
+    b: blueFromARGB(argb),
+    ...(opacityOne || a < 1 ? { opacity: a } : {}),
+  };
+}

--- a/packages/@poupe-color/src/d3/__tests__/color.test.ts
+++ b/packages/@poupe-color/src/d3/__tests__/color.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect } from 'vitest';
+import {
+  color,
+  asRGB,
+  asHSL,
+  asHCL,
+  asHCT,
+  asLab,
+  asHSV,
+  isLab,
+  isRGB,
+  isHSL,
+  isHCL,
+} from '../color';
+
+import {
+  type HSLColor,
+  rgb as rgbFactory,
+  hsl as hslFactory,
+  hcl as hclFactory,
+  lab as labFactory,
+} from 'd3-color';
+
+import { rgbaFromARGB } from '../../core/utils';
+
+describe('D3 color conversions', () => {
+  describe('color function', () => {
+    it('should handle CSS color strings', () => {
+      const result = color('red');
+      expect(result).toBeDefined();
+      expect(result instanceof rgbFactory.prototype.constructor).toBe(true);
+      expect(result).toHaveProperty('r', 255);
+      expect(result).toHaveProperty('g', 0);
+      expect(result).toHaveProperty('b', 0);
+    });
+
+    it('should handle 32-bit ARGB numbers', () => {
+      // 0xFFFF0000 = opaque red in ARGB format
+      const result = color(0xFF_FF_00_00);
+      expect(result).toBeDefined();
+      expect(result instanceof rgbFactory.prototype.constructor).toBe(true);
+      expect(result).toHaveProperty('r', 255);
+      expect(result).toHaveProperty('g', 0);
+      expect(result).toHaveProperty('b', 0);
+    });
+
+    it('should handle RGB objects', () => {
+      const result = color({ r: 255, g: 0, b: 0, opacity: 1 });
+      expect(result).toBeDefined();
+      expect(result instanceof rgbFactory.prototype.constructor).toBe(true);
+      expect(result).toHaveProperty('r', 255);
+      expect(result).toHaveProperty('g', 0);
+      expect(result).toHaveProperty('b', 0);
+    });
+
+    it('should handle Lab objects', () => {
+      const result = color({ l: 50, a: 80, b: 67, opacity: 1 });
+      expect(result).toBeDefined();
+      expect(result instanceof labFactory.prototype.constructor).toBe(true);
+      expect(result).toHaveProperty('l', 50);
+      expect(result).toHaveProperty('a', 80);
+      expect(result).toHaveProperty('b', 67);
+    });
+
+    it('should handle HCL objects', () => {
+      const result = color({ h: 0, c: 100, l: 50, opacity: 1 });
+      expect(result).toBeDefined();
+      expect(result instanceof hclFactory.prototype.constructor).toBe(true);
+      expect(result).toHaveProperty('h', 0);
+      expect(result).toHaveProperty('c', 100);
+      expect(result).toHaveProperty('l', 50);
+    });
+
+    it('should handle HSL objects', () => {
+      const result = color({ h: 0, s: 1, l: 0.5, opacity: 1 });
+      expect(result).toBeDefined();
+      expect(result instanceof hslFactory.prototype.constructor).toBe(true);
+      expect(result).toHaveProperty('h', 0);
+      expect(result).toHaveProperty('s', 1);
+      expect(result).toHaveProperty('l', 0.5);
+    });
+
+    it('should handle HSV objects', () => {
+      const result = color({ h: 0, s: 1, v: 1, opacity: 1 });
+      expect(result).toBeDefined();
+      expect(result instanceof hslFactory.prototype.constructor).toBe(true);
+      // HSV(0, 1, 1) should approximately convert to HSL(0, 1, 0.5)
+      expect(result).toHaveProperty('h', 0);
+      expect(result).toHaveProperty('s', 1);
+      expect((result as HSLColor).l).toBeCloseTo(0.5, 1);
+    });
+
+    it('should handle D3 RGBColor objects', () => {
+      const d3Color = rgbFactory(255, 0, 0);
+      const result = color(d3Color);
+      expect(result).toBe(d3Color);
+      expect(result instanceof rgbFactory.prototype.constructor).toBe(true);
+    });
+
+    it('should handle D3 LABColor objects', () => {
+      const d3Color = labFactory(50, 80, 67);
+      const result = color(d3Color);
+      expect(result).toBe(d3Color);
+      expect(result instanceof labFactory.prototype.constructor).toBe(true);
+    });
+
+    it('should handle D3 HSLColor objects', () => {
+      const d3Color = hslFactory(0, 1, 0.5);
+      const result = color(d3Color);
+      expect(result).toBe(d3Color);
+      expect(result instanceof hslFactory.prototype.constructor).toBe(true);
+    });
+
+    it('should handle D3 HCLColor objects', () => {
+      const d3Color = hclFactory(0, 100, 50);
+      const result = color(d3Color);
+      expect(result).toBe(d3Color);
+      expect(result instanceof hclFactory.prototype.constructor).toBe(true);
+    });
+
+    it('should return undefined for invalid input', () => {
+      // eslint-disable-next-line unicorn/no-null, @typescript-eslint/no-explicit-any
+      expect(color(null as any)).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(color(undefined as any)).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(color({} as any)).toBeUndefined();
+      expect(color('invalid-color')).toBeUndefined();
+    });
+  });
+
+  describe('object identity preservation', () => {
+    it('should return the same object reference when a D3 color is passed', () => {
+      // Test with RGB color
+      const rgbColor = rgbFactory(100, 150, 200);
+      const resultRgb = color(rgbColor);
+      expect(resultRgb).toBe(rgbColor); // Check object identity with toBe
+
+      // Test with HSL color
+      const hslColor = hslFactory(210, 0.5, 0.6);
+      const resultHsl = color(hslColor);
+      expect(resultHsl).toBe(hslColor);
+
+      // Test with HCL color
+      const hclColor = hclFactory(270, 30, 80);
+      const resultHcl = color(hclColor);
+      expect(resultHcl).toBe(hclColor);
+
+      // Test with Lab color
+      const labColor = labFactory(70, 20, 30);
+      const resultLab = color(labColor);
+      expect(resultLab).toBe(labColor);
+    });
+
+    it('should create new objects for non-D3 color inputs', () => {
+      // Plain object with RGB properties
+      const rgbLike = { r: 100, g: 150, b: 200 };
+      const resultRgb = color(rgbLike);
+      expect(resultRgb).not.toBe(rgbLike);
+      expect(resultRgb instanceof rgbFactory.prototype.constructor).toBe(true);
+
+      // Plain object with Lab properties
+      const labLike = { l: 70, a: 20, b: 30 };
+      const resultLab = color(labLike);
+      expect(resultLab).not.toBe(labLike);
+      expect(resultLab instanceof labFactory.prototype.constructor).toBe(true);
+
+      // CSS color string
+      const cssString = '#64a0c8'; // This is RGB(100, 160, 200)
+      const resultCss = color(cssString);
+      expect(typeof resultCss).not.toBe('string');
+      expect(resultCss instanceof rgbFactory.prototype.constructor).toBe(true);
+
+      // ARGB number
+      const argbNumber = 0xFF_64_96_C8;
+      const resultArgb = color(argbNumber);
+      expect(typeof resultArgb).not.toBe('number');
+      expect(resultArgb instanceof rgbFactory.prototype.constructor).toBe(true);
+    });
+  });
+
+  describe('asLab function', () => {
+    it('should convert custom Lab objects to D3 LabColor', () => {
+      const myColor = { l: 70, a: 20, b: 30, opacity: 0.5 };
+      const result = asLab(myColor);
+
+      expect(result instanceof labFactory.prototype.constructor).toBe(true);
+      expect(result.l).toBe(70);
+      expect(result.a).toBe(20);
+      expect(result.b).toBe(30);
+      expect(result.opacity).toBe(0.5);
+    });
+
+    it('should handle Lab objects without opacity', () => {
+      const myColor = { l: 70, a: 20, b: 30 };
+      const result = asLab(myColor);
+
+      expect(result.opacity).toBe(1); // Default opacity
+    });
+  });
+
+  describe('asRGB function', () => {
+    it('should convert custom RGB objects to D3 RGBColor', () => {
+      const myColor = { r: 255, g: 128, b: 64, opacity: 0.5 };
+      const result = asRGB(myColor);
+
+      expect(result instanceof rgbFactory.prototype.constructor).toBe(true);
+      expect(result.r).toBe(255);
+      expect(result.g).toBe(128);
+      expect(result.b).toBe(64);
+      expect(result.opacity).toBe(0.5);
+    });
+
+    it('should handle RGB objects without opacity', () => {
+      const myColor = { r: 255, g: 128, b: 64 };
+      const result = asRGB(myColor);
+
+      expect(result.opacity).toBe(1); // Default opacity
+    });
+  });
+
+  describe('asHSL function', () => {
+    it('should convert custom HSL objects to D3 HSLColor', () => {
+      const myColor = { h: 120, s: 0.75, l: 0.5, opacity: 0.8 };
+      const result = asHSL(myColor);
+
+      expect(result instanceof hslFactory.prototype.constructor).toBe(true);
+      expect(result.h).toBe(120);
+      expect(result.s).toBe(0.75);
+      expect(result.l).toBe(0.5);
+      expect(result.opacity).toBe(0.8);
+    });
+
+    it('should handle HSL objects without opacity', () => {
+      const myColor = { h: 120, s: 0.75, l: 0.5 };
+      const result = asHSL(myColor);
+
+      expect(result.opacity).toBe(1); // Default opacity
+    });
+  });
+
+  describe('asHSV function', () => {
+    it('should convert custom HSV objects to D3 HSLColor', () => {
+      const myColor = { h: 120, s: 0.8, v: 0.9, opacity: 0.7 };
+      const result = asHSV(myColor);
+
+      expect(result instanceof hslFactory.prototype.constructor).toBe(true);
+      expect(result.h).toBe(120);
+      // HSV(120, 0.8, 0.9) should convert to something in HSL space
+      // We can verify the conversion formula: l = v * (1 - s/2)
+      const expectedL = 0.9 * (1 - 0.8 / 2); // = 0.9 * 0.6 = 0.54
+      expect(result.l).toBeCloseTo(expectedL, 2);
+      expect(result.opacity).toBe(0.7);
+    });
+
+    it('should handle HSV objects without opacity', () => {
+      const myColor = { h: 120, s: 0.8, v: 0.9 };
+      const result = asHSV(myColor);
+
+      expect(result.opacity).toBe(1); // Default opacity
+    });
+
+    it('should handle edge cases', () => {
+      // When v=0, the color is black regardless of h and s
+      const black = asHSV({ h: 0, s: 1, v: 0 });
+      expect(black.l).toBe(0);
+      expect(black.s).toBe(0);
+
+      // When s=0, the color is grayscale
+      const gray = asHSV({ h: 0, s: 0, v: 0.5 });
+      expect(gray.l).toBe(0.5);
+      expect(gray.s).toBe(0);
+    });
+  });
+
+  describe('asHCL function', () => {
+    it('should convert custom HCL objects to D3 HCLColor', () => {
+      const myColor = { h: 60, c: 80, l: 70, opacity: 0.9 };
+      const result = asHCL(myColor);
+
+      expect(result instanceof hclFactory.prototype.constructor).toBe(true);
+      expect(result.h).toBe(60);
+      expect(result.c).toBe(80);
+      expect(result.l).toBe(70);
+      expect(result.opacity).toBe(0.9);
+    });
+
+    it('should handle HCL objects without opacity', () => {
+      const myColor = { h: 60, c: 80, l: 70 };
+      const result = asHCL(myColor);
+
+      expect(result.opacity).toBe(1); // Default opacity
+    });
+  });
+
+  describe('asHCT function', () => {
+    it('should convert custom HCT objects to D3 HCLColor', () => {
+      const myColor = { h: 240, c: 50, t: 60, opacity: 0.7 };
+      const result = asHCT(myColor);
+
+      expect(result instanceof hclFactory.prototype.constructor).toBe(true);
+      expect(result.h).toBe(240);
+      expect(result.c).toBe(50);
+      expect(result.l).toBe(60); // note: 't' maps to 'l' in HCLColor
+      expect(result.opacity).toBe(0.7);
+    });
+
+    it('should handle HCT objects without opacity', () => {
+      const myColor = { h: 240, c: 50, t: 60 };
+      const result = asHCT(myColor);
+
+      expect(result.opacity).toBe(1); // Default opacity
+    });
+  });
+
+  describe('type checking functions', () => {
+    it('should correctly identify Lab color instances', () => {
+      const labInstance = labFactory(50, 80, 67);
+      const rgbInstance = rgbFactory(100, 150, 200);
+
+      expect(isLab(labInstance)).toBe(true);
+      expect(isLab(rgbInstance)).toBe(false);
+      expect(isLab({ l: 50, a: 80, b: 67 })).toBe(false);
+    });
+
+    it('should correctly identify RGB color instances', () => {
+      const rgbInstance = rgbFactory(100, 150, 200);
+      const hslInstance = hslFactory(210, 0.5, 0.6);
+
+      expect(isRGB(rgbInstance)).toBe(true);
+      expect(isRGB(hslInstance)).toBe(false);
+      expect(isRGB({ r: 100, g: 150, b: 200 })).toBe(false);
+    });
+
+    it('should correctly identify HSL color instances', () => {
+      const hslInstance = hslFactory(210, 0.5, 0.6);
+      const hclInstance = hclFactory(270, 30, 80);
+
+      expect(isHSL(hslInstance)).toBe(true);
+      expect(isHSL(hclInstance)).toBe(false);
+      expect(isHSL({ h: 210, s: 0.5, l: 0.6 })).toBe(false);
+    });
+
+    it('should correctly identify HCL color instances', () => {
+      const hclInstance = hclFactory(270, 30, 80);
+      const labInstance = labFactory(50, 80, 67);
+
+      expect(isHCL(hclInstance)).toBe(true);
+      expect(isHCL(labInstance)).toBe(false);
+      expect(isHCL({ h: 270, c: 30, l: 80 })).toBe(false);
+    });
+  });
+
+  describe('color instantiation methods', () => {
+    it('should correctly identify color class instances', () => {
+      const rgbInstance = rgbFactory(100, 150, 200);
+      const hslInstance = hslFactory(210, 0.5, 0.6);
+      const hclInstance = hclFactory(270, 30, 80);
+      const labInstance = labFactory(50, 80, 67);
+
+      expect(rgbInstance instanceof rgbFactory.prototype.constructor).toBe(true);
+      expect(hslInstance instanceof hslFactory.prototype.constructor).toBe(true);
+      expect(hclInstance instanceof hclFactory.prototype.constructor).toBe(true);
+      expect(labInstance instanceof labFactory.prototype.constructor).toBe(true);
+
+      expect(rgbInstance instanceof hslFactory.prototype.constructor).toBe(false);
+      expect(hslInstance instanceof hclFactory.prototype.constructor).toBe(false);
+      expect(hclInstance instanceof rgbFactory.prototype.constructor).toBe(false);
+      expect(labInstance instanceof hslFactory.prototype.constructor).toBe(false);
+    });
+  });
+
+  describe('integration with rgbaFromARGB', () => {
+    it('should correctly convert ARGB values', () => {
+      // 0xFF00FF00 = opaque green in ARGB format
+      const rgba = rgbaFromARGB(0xFF_00_FF_00);
+      const result = asRGB(rgba);
+
+      expect(result.r).toBe(0);
+      expect(result.g).toBe(255);
+      expect(result.b).toBe(0);
+      expect(result.opacity).toBe(1);
+    });
+
+    it('should handle transparency in ARGB values', () => {
+      // 0x80FF0000 = semi-transparent red in ARGB format
+      const rgba = rgbaFromARGB(0x80_FF_00_00);
+      const result = asRGB(rgba);
+
+      expect(result.r).toBe(255);
+      expect(result.g).toBe(0);
+      expect(result.b).toBe(0);
+      expect(result.opacity).toBeCloseTo(0.5, 1); // Alpha 0x80 = ~0.5 opacity
+    });
+  });
+});

--- a/packages/@poupe-color/src/d3/color.ts
+++ b/packages/@poupe-color/src/d3/color.ts
@@ -1,0 +1,176 @@
+import {
+  LabColor,
+  RGBColor,
+  HSLColor,
+  HCLColor,
+  color as factory,
+  rgb as rgbFactory,
+  hsl as hslFactory,
+  hcl as hclFactory,
+  lab as labFactory,
+} from 'd3-color';
+
+import type {
+  AnyColor,
+  RGBColor as myRGBColor,
+  LabColor as myLabColor,
+  HCLColor as myHCLColor,
+  HCTColor as myHCTColor,
+  HSLColor as myHSLColor,
+  HSVColor as myHSVColor,
+} from '../core/types';
+
+import { rgbaFromARGB } from '../core/utils';
+
+/**
+ * Converts various color representations to a D3 color object.
+ *
+ * @param color - A color input that can be a string, number, or color object
+ * @returns A D3 color object (LabColor, RGBColor, HSLColor, or HCLColor) or undefined if conversion fails
+ * @remarks Supports conversion from:
+ * - CSS color strings
+ * - 32-bit ARGB numbers
+ * - RGB objects with optional opacity
+ * - Lab objects with optional opacity
+ * - HCL objects with optional opacity
+ * - HSL objects with optional opacity
+ * - HSV objects with optional opacity
+ */
+export function color(
+  color: AnyColor,
+): LabColor | RGBColor | HSLColor | HCLColor | undefined {
+  if (typeof color === 'string') {
+    const c = factory(color);
+    return c === null ? undefined : c;
+  } else if (typeof color === 'number') {
+    return asRGB(rgbaFromARGB(color));
+  } else if (!color) {
+    return undefined;
+  } else if (isLab(color)) {
+    return color as LabColor;
+  } else if (isRGB(color)) {
+    return color as RGBColor;
+  } else if (isHSL(color)) {
+    return color as HSLColor;
+  } else if (isHCL(color)) {
+    return color as HCLColor;
+  } else if ('l' in color && 'a' in color && 'b' in color) {
+    return asLab(color);
+  } else if ('r' in color && 'g' in color && 'b' in color) {
+    return asRGB(color);
+  } else if ('h' in color && 'c' in color && 'l' in color) {
+    return asHCL(color);
+  } else if ('h' in color && 's' in color && 'l' in color) {
+    return asHSL(color);
+  } else if ('h' in color && 's' in color && 'v' in color) {
+    return asHSV(color);
+  } else {
+    return undefined;
+  }
+}
+
+/**
+ * Converts a custom L*a*b* color object to a D3 LABColor object.
+ *
+ * @param color - A L*a*b* color object with lightness, a, b, and optional opacity values
+ * @returns A D3 LABColor object representing the converted color
+ */
+export function asLab(color: myLabColor): LabColor {
+  return labFactory(color.l, color.a, color.b, color.opacity ?? 1);
+}
+
+/**
+ * Converts a custom RGB color object to a D3 RGBColor object.
+ *
+ * @param color - An RGB color object with red, green, blue, and optional opacity values
+ * @returns A D3 RGBColor object representing the converted color
+ */
+export function asRGB(color: myRGBColor): RGBColor {
+  return rgbFactory(color.r, color.g, color.b, color.opacity ?? 1);
+}
+
+/**
+ * Converts a custom HSL color object to a D3 HSLColor object.
+ *
+ * @param color - An HSL color object with hue, saturation, lightness, and optional opacity values
+ * @returns A D3 HSLColor object representing the converted color
+ */
+export function asHSL(color: myHSLColor): HSLColor {
+  return hslFactory(color.h, color.s, color.l, color.opacity ?? 1);
+}
+
+/**
+ * Converts a custom HSV color object to a D3 HSLColor object.
+ *
+ * @param color - An HSV color object with hue, saturation, value, and optional opacity values
+ * @returns A D3 HSLColor object representing the converted HSV color in HSL space
+ * @remarks Performs HSV to HSL conversion using the formula:
+ * - L = V * (1 - S/2)
+ * - S = (V - L) / min(L, 1 - L) if L is not 0 or 1, otherwise 0
+ */
+export function asHSV(color: myHSVColor): HSLColor {
+  const l = color.v * (1 - color.s / 2);
+  const s = l === 0 || l === 1 ? 0 : (color.v - l) / Math.min(l, 1 - l);
+  return hslFactory(color.h, s, l, color.opacity ?? 1);
+}
+
+/**
+ * Converts a custom HCL color object to a D3 HCLColor object.
+ *
+ * @param color - An HCL color object with hue, chroma, lightness, and optional opacity values
+ * @returns A D3 HCLColor object representing the converted color
+ */
+export function asHCL(color: myHCLColor): HCLColor {
+  return hclFactory(color.h, color.c, color.l, color.opacity ?? 1);
+}
+
+/**
+ * Converts a custom HCT color object to a D3 HCLColor object.
+ *
+ * @param color - An HCT color object with hue, chroma, tone, and optional opacity values
+ * @returns A D3 HCLColor object where the tone value is mapped to the lightness parameter
+ * @remarks HCT (Hue, Chroma, Tone) is converted to HCL by using the tone value as lightness
+ */
+export function asHCT(color: myHCTColor): HCLColor {
+  return hclFactory(color.h, color.c, color.t, color.opacity ?? 1);
+}
+
+/**
+ * Checks if the given color is an instance of a L*a*b* color.
+ *
+ * @param color - The color to check
+ * @returns A boolean indicating whether the color is a D3 LAB color instance
+ */
+export function isLab(color: unknown): boolean {
+  return color instanceof labFactory.prototype.constructor;
+}
+
+/**
+ * Checks if the given color is an instance of an RGB color.
+ *
+ * @param color - The color to check
+ * @returns A boolean indicating whether the color is a D3 RGB color instance
+ */
+export function isRGB(color: unknown): boolean {
+  return color instanceof rgbFactory.prototype.constructor;
+}
+
+/**
+ * Checks if the given color is an instance of an HSL color.
+ *
+ * @param color - The color to check
+ * @returns A boolean indicating whether the color is a D3 HSL color instance
+ */
+export function isHSL(color: unknown): boolean {
+  return color instanceof hslFactory.prototype.constructor;
+}
+
+/**
+ * Checks if the given color is an instance of an HCL color.
+ *
+ * @param color - The color to check
+ * @returns A boolean indicating whether the color is a D3 HCL color instance
+ */
+export function isHCL(color: unknown): boolean {
+  return color instanceof hclFactory.prototype.constructor;
+}

--- a/packages/@poupe-color/src/d3/index.ts
+++ b/packages/@poupe-color/src/d3/index.ts
@@ -1,0 +1,19 @@
+export {
+  color,
+  isLab,
+  isRGB,
+  isHSL,
+  isHCL,
+} from './color';
+
+export {
+  type Color,
+  type LabColor,
+  type RGBColor,
+  type HSLColor,
+  type HCLColor,
+  lab,
+  rgb,
+  hsl,
+  hcl,
+} from 'd3-color';

--- a/packages/@poupe-color/src/hct.ts
+++ b/packages/@poupe-color/src/hct.ts
@@ -1,0 +1,1 @@
+export type HCT = unknown & {}; // TODO: implement

--- a/packages/@poupe-color/src/index.ts
+++ b/packages/@poupe-color/src/index.ts
@@ -1,0 +1,2 @@
+export * from './hct';
+export * from './core/types';

--- a/packages/@poupe-color/src/utils/index.ts
+++ b/packages/@poupe-color/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from '../core/utils';

--- a/packages/@poupe-color/tsconfig.json
+++ b/packages/@poupe-color/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": [
+    "src",
+    "build.config.ts",
+    "vitest.config.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/@poupe-color/vitest.config.ts
+++ b/packages/@poupe-color/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node', // or 'jsdom' if your tests ever require a DOM
+    globals: true, // Optional: enables global APIs like describe, it, expect
+    coverage: {
+      provider: 'v8', // or 'istanbul'
+      reporter: ['text', 'json-summary', 'json', 'html'],
+      include: ['src/**/*.ts'], // Adjust based on your source code location
+      exclude: [
+        // Add patterns for files/directories to exclude from coverage
+        'src/index.ts', // Often entry points don't need coverage
+        '**/*.spec.ts',
+        '**/*.test.ts',
+        '**/__tests__/**',
+        '**/dist/**',
+      ],
+    },
+  },
+  // If you use path aliases in your project (e.g., in tsconfig.json),
+  // you might need to configure them here as well.
+  // resolve: {
+  //   alias: {
+  //     // Example: '@': path.resolve(__dirname, './src'),
+  //   },
+  // },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,43 @@ importers:
         specifier: ^0.0.43
         version: 0.0.43
 
+  packages/@poupe-color:
+    dependencies:
+      d3-color:
+        specifier: ^3.1.0
+        version: 3.1.0
+    devDependencies:
+      '@poupe/eslint-config':
+        specifier: ^0.6.3
+        version: 0.6.3(jiti@2.4.2)(typescript@5.8.3)(vue-eslint-parser@10.1.3(eslint@9.26.0(jiti@2.4.2)))
+      '@types/d3-color':
+        specifier: ^3.1.3
+        version: 3.1.3
+      '@types/node':
+        specifier: ^20.17.46
+        version: 20.17.46
+      eslint:
+        specifier: ^9.26.0
+        version: 9.26.0(jiti@2.4.2)
+      npm-run-all2:
+        specifier: ^8.0.1
+        version: 8.0.1
+      publint:
+        specifier: ^0.3.12
+        version: 0.3.12
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      unbuild:
+        specifier: 3.5.0
+        version: 3.5.0(typescript@5.8.3)(vue-sfc-transformer@0.1.10(esbuild@0.25.4)(vue@3.5.13(typescript@5.8.3)))(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))
+      vitest:
+        specifier: ^3.1.3
+        version: 3.1.3(@types/node@20.17.46)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vue-tsc:
+        specifier: ~2.2.10
+        version: 2.2.10(typescript@5.8.3)
+
   packages/@poupe-css:
     devDependencies:
       '@poupe/eslint-config':
@@ -1798,6 +1835,9 @@ packages:
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
@@ -2835,6 +2875,10 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -8286,6 +8330,8 @@ snapshots:
 
   '@types/argparse@1.0.38': {}
 
+  '@types/d3-color@3.1.3': {}
+
   '@types/estree@1.0.7': {}
 
   '@types/jsdom@21.1.7':
@@ -9521,6 +9567,8 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.1.3: {}
+
+  d3-color@3.1.0: {}
 
   data-uri-to-buffer@4.0.1: {}
 

--- a/poupe.code-workspace
+++ b/poupe.code-workspace
@@ -4,6 +4,10 @@
 			"path": "."
 		},
 		{
+			"name": "@poupe/color",
+			"path": "packages/@poupe-color"
+		},
+		{
 			"name": "@poupe/css",
 			"path": "packages/@poupe-css"
 		},


### PR DESCRIPTION
d3-color conversions. Hct class pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `@poupe/color` package, providing utilities for color manipulation and conversion between various color spaces (HCT, HCL, RGB, HSL, Lab, HSV) built on D3.js.
  - Added functions for color parsing, conversion, and type checking, supporting flexible input formats (CSS strings, ARGB numbers, color objects).
  - Provided integration points for use with other Poupe ecosystem tools.

- **Documentation**
  - Added comprehensive README with usage examples, supported color spaces, and integration details.

- **Tests**
  - Implemented test suites to ensure correctness of color utilities and conversions.

- **Chores**
  - Added configuration files for TypeScript, build, linting, and testing.
  - Updated workspace configuration to include the new package.
  - Added editor configuration for consistent code style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->