### PR TITLE
feat(poupe-css): add nested css rules formatter

### DIFF
--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -168,8 +168,42 @@ A type-safe wrapper around Object.keys that preserves the object's key types.
 #### `keys<T, K extends keyof T>(object: T, valid?: (key: keyof T) => boolean): Generator<K>`
 A generator function that yields keys of an object that pass an optional validation function.
 
-#### `pairs<K extends string, T1, T2>(object: Record<K, T1>, valid?: (k: K, v: T1) => boolean): Generator<[K, T2]>`
-A generator function that yields valid key-value pairs from an object.
+```typescript
+import { keys } from '@poupe/css';
+
+const obj = { a: 1, b: 2, _private: 3 };
+
+// Use with default validation (includes all keys)
+for (const key of keys(obj)) {
+  console.log(key); // "a", "b", "_private"
+}
+
+// Use with custom validation
+for (const key of keys(obj, k => !k.startsWith('_'))) {
+  console.log(key); // "a", "b"
+}
+```
+
+#### `pairs<K extends string, T>(object: Record<K, T>, valid?: (k: K, v: T) => boolean): Generator<[K, T]>`
+A generator function that yields valid key-value pairs from an object. Allows providing a custom validation function
+to determine which pairs to include.
+
+```typescript
+import { pairs } from '@poupe/css';
+
+const obj = { color: 'red', fontSize: '16px', _private: 'hidden', empty: '' };
+
+// Use with default validation (excludes keys starting with underscore and null/empty values)
+for (const [key, value] of pairs(obj)) {
+  console.log(`${key}: ${value}`); // "color: red", "fontSize: 16px"
+}
+
+// Use with custom validation
+const customValid = (key: string, value: unknown) => typeof value === 'string' && value.length > 3;
+for (const [key, value] of pairs(obj, customValid)) {
+  console.log(`${key}: ${value}`); // "color: red", "_private: hidden"
+}
+```
 
 #### `defaultValidPair<K extends string, T>(key: K, value: T): boolean`
 Validates if a key-value pair meets default criteria:

--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -68,6 +68,8 @@ type CSSPropertiesOptions = {
 
 #### `stringifyCSSProperties<K extends string>(object: CSSProperties<K>, options?: CSSPropertiesOptions): string`
 Converts a CSSProperties object into a formatted CSS string representation with proper indentation.
+Property values are intelligently formatted based on their type and the CSS property name - space-delimited
+properties (like margin, padding) use spaces between multiple values, while other properties use commas.
 
 ```typescript
 import { stringifyCSSProperties } from '@poupe/css';
@@ -75,7 +77,8 @@ import { stringifyCSSProperties } from '@poupe/css';
 const styles = {
   fontSize: '16px',
   backgroundColor: 'red',
-  margin: [10, '20px', '30px', '40px']
+  margin: [10, '20px', '30px', '40px'],
+  fontFamily: ['Arial', 'sans-serif']
 };
 
 // Default multi-line formatting
@@ -83,24 +86,13 @@ const cssString = stringifyCSSProperties(styles);
 // "{
 //   font-size: 16px;
 //   background-color: red;
-//   margin: 10, 20px, 30px, 40px;
-//   }"
+//   margin: 10 20px 30px 40px;
+//   font-family: Arial, sans-serif;
+// }"
 
 // Inline formatting
 const inlineCSS = stringifyCSSProperties(styles, { inline: true });
-// "{ font-size: 16px; background-color: red; margin: 10, 20px, 30px, 40px }"
-
-// Custom indentation and prefix
-const customCSS = stringifyCSSProperties(styles, {
-  indent: '    ',
-  prefix: '  ',
-  singleLineThreshold: 3
-});
-// "{
-//       font-size: 16px;
-//       background-color: red;
-//       margin: 10, 20px, 30px, 40px;
-//   }"
+// "{ font-size: 16px; background-color: red; margin: 10 20px 30px 40px; font-family: Arial, sans-serif }"
 ```
 
 #### `formatCSSProperties<K extends string>(object: CSSProperties<K>): string[]`
@@ -126,16 +118,23 @@ const cssLines = formatCSSProperties(styles);
 // ]
 ```
 
-#### `formatCSSValue(value: CSSValue): string`
-Formats a CSS value into a string. If the value is an array, it joins the elements with a comma and a space.
-If the value is a string containing spaces, it encloses the string in double quotes.
+#### `formatCSSValue(value: CSSValue, useComma = true): string`
+Formats a CSS value into a string. If the value is an array:
+- By default, it joins the elements with commas (appropriate for properties like `font-family`)
+- When `useComma` is set to `false`, it uses spaces (appropriate for properties like `margin` or `padding`)
+
+The function automatically handles quoting strings that contain spaces (except CSS functions like
+`rgb()` or `calc()`), enclosing them in double quotes.
 
 ```typescript
 import { formatCSSValue } from '@poupe/css';
 
 formatCSSValue('16px'); // "16px"
 formatCSSValue('Open Sans'); // "\"Open Sans\""
-formatCSSValue([10, '20px', '30px']); // "10, 20px, 30px"
+formatCSSValue([10, '20px', '30px']); // "10, 20px, 30px" (comma-separated by default)
+formatCSSValue([10, '20px', '30px'], false); // "10 20px 30px" (space-separated)
+formatCSSValue('rgb(255, 0, 0)'); // "rgb(255, 0, 0)" - Not quoted despite spaces
+formatCSSValue('calc(100% - 20px)'); // "calc(100% - 20px)" - Not quoted despite spaces
 ```
 
 #### `properties<K extends string>(object: CSSProperties<K>): Generator<[K, CSSValue]>`

--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -6,10 +6,23 @@
 
 A TypeScript utility library for CSS property manipulation, formatting, and CSS-in-JS operations.
 
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [API Reference](#api-reference)
+  - [Types](#types)
+  - [CSS Property Functions](#css-property-functions)
+  - [CSS Rules Functions](#css-rules-functions)
+  - [Utility Functions](#utility-functions)
+- [Integration with Poupe Ecosystem](#integration-with-poupe-ecosystem)
+- [Requirements](#requirements)
+- [License](#license)
+
 ## Features
 
 - 🛠️ Utilities for manipulating CSS properties
-- 🔄 Convert between camelCase and kebab-case CSS properties
+- 🔄 Bidirectional conversion between camelCase and kebab-case CSS properties
 - 📝 Format CSS for use in JavaScript
 - 🎨 CSS-in-JS helpers and type definitions
 - 📦 Lightweight, tree-shakable API
@@ -350,6 +363,47 @@ kebabCase('XMLHttpRequest'); // 'xml-http-request'
 kebabCase('camelCase');      // 'camel-case'
 kebabCase('snake_case');     // 'snake-case'
 kebabCase('WebkitTransition'); // '-webkit-transition'
+```
+
+#### `camelCase(s: string): string`
+Converts a given string to camelCase:
+- Transforms kebab-case, PascalCase, and snake_case to camelCase
+- Properly handles vendor prefixes by removing the leading hyphen
+- Correctly handles acronyms and preserves internal capitalization
+
+```typescript
+import { camelCase } from '@poupe/css';
+
+camelCase('kebab-case');      // 'kebabCase'
+camelCase('PascalCase');      // 'pascalCase'
+camelCase('snake_case');      // 'snakeCase'
+camelCase('-webkit-transition'); // 'webkitTransition'
+camelCase('HTMLElement');     // 'htmlElement'
+camelCase('BGColor');         // 'bgColor'
+```
+
+### Case Conversion Example
+
+```typescript
+import { kebabCase, camelCase } from '@poupe/css';
+
+// Kebab-case to camelCase
+const camelProperty = camelCase('background-color'); // 'backgroundColor'
+
+// CamelCase to kebab-case
+const kebabProperty = kebabCase('backgroundColor'); // 'background-color'
+
+// Useful for converting between CSS and JavaScript property names
+const styleObject = {
+  backgroundColor: 'red',
+  fontSize: '16px'
+};
+
+// Convert to CSS properties
+const cssProperties = Object.entries(styleObject).map(
+  ([key, value]) => `${kebabCase(key)}: ${value};`
+);
+// ['background-color: red;', 'font-size: 16px;']
 ```
 
 ## Integration with Poupe Ecosystem

--- a/packages/@poupe-css/package.json
+++ b/packages/@poupe-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/css",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "description": "A TypeScript utility library for CSS property manipulation, formatting, and CSS-in-JS operations",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-css/package.json
+++ b/packages/@poupe-css/package.json
@@ -6,22 +6,30 @@
   "author": "Alejandro Mery <amery@apptly.co>",
   "license": "MIT",
   "keywords": [
+    "camelCase",
+    "case-conversion",
     "css",
     "css-in-js",
-    "typescript",
-    "styling",
-    "formatter",
     "css-properties",
+    "css-rules",
     "css-utilities",
+    "formatter",
     "kebab-case",
+    "nested-css",
+    "poupe",
     "stringify",
-    "poupe"
+    "styling",
+    "typescript"
   ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/poupe-ui/poupe.git",
     "directory": "packages/@poupe-css"
   },
+  "bugs": {
+    "url": "https://github.com/poupe-ui/poupe/issues"
+  },
+  "homepage": "https://github.com/poupe-ui/poupe/tree/main/packages/@poupe-css#readme",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",

--- a/packages/@poupe-css/src/index.ts
+++ b/packages/@poupe-css/src/index.ts
@@ -6,8 +6,19 @@ export {
   formatCSSProperties,
   properties,
 
-  // omit formatCSSValue - only exported for tests
+  // omit internal - formatCSSValue, quoted and spaceDelimitedProperties
 } from './properties';
+
+export {
+  type CSSRuleObject,
+  type CSSRules,
+  type CSSRulesValue,
+  type CSSRulesFormatOptions,
+  stringifyCSSRules,
+  formatCSSRules,
+  formatCSSRulesArray,
+  defaultValidCSSRule,
+} from './rules';
 
 export {
   unsafeKeys,

--- a/packages/@poupe-css/src/index.ts
+++ b/packages/@poupe-css/src/index.ts
@@ -27,4 +27,5 @@ export {
   defaultValidPair,
 
   kebabCase,
+  camelCase,
 } from './utils';

--- a/packages/@poupe-css/src/properties.test.ts
+++ b/packages/@poupe-css/src/properties.test.ts
@@ -267,6 +267,34 @@ describe('formatCSSValue', () => {
     expect(formatCSSValue(['solid 1px', 'dotted 2px'])).toBe('"solid 1px", "dotted 2px"');
     expect(formatCSSValue(['Arial', 'Times New Roman'])).toBe('Arial, "Times New Roman"');
   });
+
+  it('does not quote CSS functions with spaces between arguments', () => {
+    expect(formatCSSValue('rgb(255, 0, 0)')).toBe('rgb(255, 0, 0)');
+    expect(formatCSSValue('rgba(255, 0, 0, 0.5)')).toBe('rgba(255, 0, 0, 0.5)');
+    expect(formatCSSValue('calc(100% - 20px)')).toBe('calc(100% - 20px)');
+    expect(formatCSSValue('linear-gradient(to right, red, blue)')).toBe('linear-gradient(to right, red, blue)');
+  });
+
+  it('correctly handles arrays with CSS functions', () => {
+    expect(formatCSSValue(['rgb(255, 0, 0)', 'rgb(0, 0, 255)'])).toBe('rgb(255, 0, 0), rgb(0, 0, 255)');
+    expect(formatCSSValue(['url(image.jpg)', 'linear-gradient(to right, red, blue)'])).toBe(
+      'url(image.jpg), linear-gradient(to right, red, blue)',
+    );
+  });
+
+  it('correctly handles mixed arrays with CSS functions and regular strings with spaces', () => {
+    expect(formatCSSValue(['Times New Roman', 'calc(100% - 20px)'])).toBe('"Times New Roman", calc(100% - 20px)');
+    expect(formatCSSValue(['rgb(255, 0, 0)', 'solid 1px black'])).toBe('rgb(255, 0, 0), "solid 1px black"');
+  });
+
+  it('handles nested CSS functions correctly', () => {
+    expect(formatCSSValue('linear-gradient(to right, rgba(255, 0, 0, 0.5), blue)')).toBe(
+      'linear-gradient(to right, rgba(255, 0, 0, 0.5), blue)',
+    );
+    expect(formatCSSValue('drop-shadow(0 0 0.75rem rgba(0, 0, 0, 0.5))')).toBe(
+      'drop-shadow(0 0 0.75rem rgba(0, 0, 0, 0.5))',
+    );
+  });
 });
 
 describe('properties generator', () => {

--- a/packages/@poupe-css/src/properties.test.ts
+++ b/packages/@poupe-css/src/properties.test.ts
@@ -6,6 +6,7 @@ import {
   formatCSSValue,
   properties,
   stringifyCSSProperties,
+  spaceDelimitedProperties,
 } from './properties';
 
 describe('stringifyCSSProperties', () => {
@@ -108,7 +109,7 @@ describe('stringifyCSSProperties', () => {
     };
     const result = stringifyCSSProperties(cssProps, options);
 
-    expect(result).toBe('{\n»   • color: red;\n»   • font-size: 16px;\n»   • margin: 10, 20\n» }');
+    expect(result).toBe('{\n»   • color: red;\n»   • font-size: 16px;\n»   • margin: 10 20\n» }');
   });
 });
 
@@ -238,6 +239,27 @@ describe('formatCSSProperties', () => {
 
     expect(result).toHaveLength(4);
   });
+
+  it('formats space-delimited properties correctly', () => {
+    const cssProps: CSSProperties = {
+      margin: [10, 20, 30, 40],
+      padding: ['1em', '2em'],
+      transform: ['translateX(10px)', 'rotate(45deg)'],
+    };
+    const result = formatCSSProperties(cssProps);
+
+    // Find the relevant properties
+    const marginLine = result.find(line => line.startsWith('margin:'));
+    const paddingLine = result.find(line => line.startsWith('padding:'));
+    const transformLine = result.find(line => line.startsWith('transform:'));
+
+    // Check for space-delimited values for margin and padding
+    expect(marginLine).toBe('margin: 10 20 30 40');
+    expect(paddingLine).toBe('padding: 1em 2em');
+
+    // transform should use spaces between functions
+    expect(transformLine).toBe('transform: translateX(10px) rotate(45deg)');
+  });
 });
 
 describe('formatCSSValue', () => {
@@ -252,10 +274,31 @@ describe('formatCSSValue', () => {
     expect(formatCSSValue(-5)).toBe('-5');
   });
 
-  it('formats array values', () => {
+  it('formats array values with commas by default', () => {
     expect(formatCSSValue(['red', 'blue'])).toBe('red, blue');
     expect(formatCSSValue([10, 20, 30])).toBe('10, 20, 30');
     expect(formatCSSValue(['red', 10])).toBe('red, 10');
+  });
+
+  it('formats array values with spaces when useComma is false', () => {
+    expect(formatCSSValue(['red', 'blue'], false)).toBe('red blue');
+    expect(formatCSSValue([10, 20, 30], false)).toBe('10 20 30');
+    expect(formatCSSValue(['1em', '2em', '3em'], false)).toBe('1em 2em 3em');
+  });
+
+  it('correctly formats values for space-delimited properties', () => {
+    // Test a few properties from the spaceDelimitedProperties set
+    for (const prop of [...spaceDelimitedProperties].slice(0, 3)) {
+      const kebabProp = prop; // Already in kebab case in the set
+      const values = ['10px', '20px', '30px'];
+
+      // Format with useComma = false for space-delimited properties
+      const formatted = formatCSSValue(values, false);
+      expect(formatted).toBe('10px 20px 30px');
+
+      // Make sure the property is actually in the set
+      expect(spaceDelimitedProperties.has(kebabProp)).toBe(true);
+    }
   });
 
   it('quotes string values containing spaces', () => {
@@ -266,6 +309,11 @@ describe('formatCSSValue', () => {
   it('quotes array values containing spaces', () => {
     expect(formatCSSValue(['solid 1px', 'dotted 2px'])).toBe('"solid 1px", "dotted 2px"');
     expect(formatCSSValue(['Arial', 'Times New Roman'])).toBe('Arial, "Times New Roman"');
+  });
+
+  it('quotes array values containing spaces with space delimiter', () => {
+    expect(formatCSSValue(['solid 1px', 'dotted 2px'], false)).toBe('"solid 1px" "dotted 2px"');
+    expect(formatCSSValue(['small', 'Times New Roman'], false)).toBe('small "Times New Roman"');
   });
 
   it('does not quote CSS functions with spaces between arguments', () => {

--- a/packages/@poupe-css/src/properties.ts
+++ b/packages/@poupe-css/src/properties.ts
@@ -4,7 +4,7 @@ import {
 } from './utils';
 
 export type CSSProperties<K extends string = string> = Record<K, CSSValue>;
-export type CSSValue = string | number | (string | number)[];
+export type CSSValue = string | number | boolean | (string | number | boolean)[];
 
 /**
  * Configuration options for CSS properties stringification.
@@ -95,15 +95,23 @@ export function formatCSSValue(value: CSSValue): string {
 }
 
 /**
- * Encloses a CSS value in double quotes if it is a string containing spaces.
- * Otherwise, converts the value to a string.
+ * Encloses a CSS value in double quotes if it is a string containing spaces,
+ * except for CSS functions which should not be quoted.
  *
  * @param v - The CSS value to process.
  * @returns The processed CSS value as a string.
  */
 function quoted(v: CSSValue): string {
-  if (typeof v === 'string' && v.includes(' ')) {
-    return `"${v}"`;
+  if (typeof v === 'boolean') {
+    return v ? 'true' : 'false';
+  } else if (typeof v === 'string') {
+    // Check if this is a CSS function (contains parentheses)
+    const isCssFunction = /^[a-zA-Z-]+\(.*\)$/.test(v.trim());
+
+    // Only quote strings with spaces that are not CSS functions
+    if (v.includes(' ') && !isCssFunction) {
+      return `"${v}"`;
+    }
   }
   return String(v);
 }

--- a/packages/@poupe-css/src/rules.test.ts
+++ b/packages/@poupe-css/src/rules.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect } from 'vitest';
+import {
+  type CSSRules,
+  type CSSRuleObject,
+  type CSSRulesFormatOptions,
+  stringifyCSSRules,
+  formatCSSRules,
+  formatCSSRulesArray,
+  defaultValidCSSRule,
+} from './rules';
+
+describe('stringifyCSSRules', () => {
+  it('formats basic CSS rules', () => {
+    const rules: CSSRules = {
+      '.container': {
+        color: 'red',
+        fontSize: '16px',
+      },
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    expect(result).toBe(
+      '.container {\n'
+      + '  color: red;\n'
+      + '  fontSize: 16px;\n'
+      + '}',
+    );
+  });
+
+  it('formats empty rules', () => {
+    const rules: CSSRules = {};
+    const result = stringifyCSSRules(rules);
+
+    expect(result).toBe('');
+  });
+
+  it('handles nested rules', () => {
+    const rules: CSSRules = {
+      '.container': {
+        'color': 'red',
+        '.child': {
+          backgroundColor: 'blue',
+        },
+      },
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    expect(result).toBe(
+      '.container {\n'
+      + '  color: red;\n'
+      + '  .child {\n'
+      + '    backgroundColor: blue;\n'
+      + '  }\n'
+      + '}',
+    );
+  });
+
+  it('handles array values', () => {
+    const rules: CSSRules = {
+      '.container': {
+        fontFamily: ['Arial', 'sans-serif'],
+      },
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    expect(result).toBe(
+      '.container {\n'
+      + '  fontFamily: Arial, sans-serif;\n'
+      + '}',
+    );
+  });
+
+  it('respects custom options', () => {
+    const rules: CSSRules = {
+      '.container': {
+        color: 'red',
+        fontSize: '16px',
+      },
+    };
+
+    const options: CSSRulesFormatOptions & { newLine: string } = {
+      indent: '    ',
+      prefix: '• ',
+      newLine: '\r\n',
+    };
+
+    const result = stringifyCSSRules(rules, options);
+
+    expect(result).toBe(
+      '• .container {\r\n'
+      + '•     color: red;\r\n'
+      + '•     fontSize: 16px;\r\n'
+      + '• }',
+    );
+  });
+
+  it('handles at-rules correctly', () => {
+    const rules: CSSRules = {
+      '@media (max-width: 768px)': {
+        '.container': {
+          fontSize: '14px',
+        },
+      },
+      '@import': 'url("styles.css")',
+      '@keyframes spin': {
+        '0%': { transform: 'rotate(0deg)' },
+        '100%': { transform: 'rotate(360deg)' },
+      },
+      // Empty at-rule that should be preserved
+      '@supports (display: grid)': {},
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    // The @supports rule with empty content should be preserved as is
+    expect(result).toContain('@supports (display: grid);');
+
+    // Other rules should be formatted normally
+    expect(result).toContain('@import: url("styles.css");');
+    expect(result).toContain('@media (max-width: 768px) {');
+    expect(result).toContain('@keyframes spin {');
+    expect(result).toContain('0% {');
+    expect(result).toContain('transform: rotate(0deg);');
+    expect(result).toContain('100% {');
+    expect(result).toContain('transform: rotate(360deg);');
+  });
+
+  it('handles null values', () => {
+    const rules: CSSRules = {
+      '.container': {
+        color: 'red',
+        // eslint-disable-next-line unicorn/no-null
+        backgroundColor: null,
+        fontSize: '16px',
+      },
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    // Null values should be ignored
+    expect(result).not.toContain('backgroundColor');
+    expect(result).toContain('color: red;');
+    expect(result).toContain('fontSize: 16px;');
+  });
+
+  it('formats rules that are compatible with tailwindcss plugin API', () => {
+    const rules: CSSRuleObject = {
+      '.container': {
+        'color': 'red',
+        'fontSize': '16px',
+        '@media (max-width: 768px)': {
+          fontSize: '14px',
+        },
+      },
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    expect(result).toContain('.container {');
+    expect(result).toContain('color: red;');
+    expect(result).toContain('fontSize: 16px;');
+    expect(result).toContain('@media (max-width: 768px) {');
+    expect(result).toContain('fontSize: 14px;');
+  });
+});
+
+describe('formatCSSRules', () => {
+  it('returns empty array for empty rules', () => {
+    const rules: CSSRules = {};
+    const result = formatCSSRules(rules);
+
+    expect(result).toEqual([]);
+  });
+
+  it('formats basic rules with string values', () => {
+    const rules: CSSRules = {
+      color: 'red',
+      fontSize: '16px',
+    };
+
+    const result = formatCSSRules(rules);
+
+    expect(result).toEqual([
+      'color: red;',
+      'fontSize: 16px;',
+    ]);
+  });
+
+  it('ignores empty string values', () => {
+    const rules: CSSRules = {
+      color: 'red',
+      border: '',
+    };
+
+    const result = formatCSSRules(rules);
+
+    expect(result).toEqual(['color: red;']);
+    expect(result).not.toContain('border: ;');
+  });
+
+  it('formats nested rules correctly', () => {
+    const rules: CSSRules = {
+      '.parent': {
+        'color': 'red',
+        '.child': {
+          fontSize: '12px',
+        },
+      },
+    };
+
+    const result = formatCSSRules(rules);
+
+    expect(result).toEqual([
+      '.parent {',
+      '  color: red;',
+      '  .child {',
+      '    fontSize: 12px;',
+      '  }',
+      '}',
+    ]);
+  });
+
+  it('uses custom indentation and prefix', () => {
+    const rules: CSSRules = {
+      '.parent': {
+        color: 'red',
+        fontSize: '16px',
+      },
+    };
+
+    const options: CSSRulesFormatOptions = {
+      indent: '--',
+      prefix: '> ',
+    };
+
+    const result = formatCSSRules(rules, options);
+
+    expect(result).toEqual([
+      '> .parent {',
+      '> --color: red;',
+      '> --fontSize: 16px;',
+      '> }',
+    ]);
+  });
+
+  it('applies custom validation function', () => {
+    const rules: CSSRules = {
+      color: 'red',
+      fontSize: '16px',
+      _internal: 'value', // Should be filtered out by custom validator
+      margin: '10px',
+    };
+
+    // Custom validator that filters out keys starting with underscore
+    const options: CSSRulesFormatOptions = {
+      valid: key => !key.startsWith('_'),
+    };
+
+    const result = formatCSSRules(rules, options);
+
+    expect(result).toContain('color: red;');
+    expect(result).toContain('fontSize: 16px;');
+    expect(result).toContain('margin: 10px;');
+    expect(result).not.toContain('_internal');
+  });
+});
+
+describe('formatCSSRulesArray', () => {
+  it('handles array of strings', () => {
+    const rules = ['color: red', 'font-size: 16px'];
+    const result = formatCSSRulesArray(rules);
+
+    expect(result).toEqual([
+      'color: red;',
+      'font-size: 16px;',
+    ]);
+  });
+
+  it('handles array of objects', () => {
+    const rules: CSSRules[] = [
+      { color: 'red' },
+      { fontSize: '16px' },
+    ];
+
+    const result = formatCSSRulesArray(rules);
+
+    expect(result).toEqual([
+      'color: red;',
+      'fontSize: 16px;',
+    ]);
+  });
+
+  it('handles empty array', () => {
+    const rules: string[] = [];
+    const result = formatCSSRulesArray(rules);
+
+    expect(result).toEqual([]);
+  });
+
+  it('preserves empty strings for whitespace', () => {
+    const rules = ['color: red', '', 'font-size: 16px'];
+    const result = formatCSSRulesArray(rules);
+
+    expect(result).toEqual([
+      'color: red;',
+      '', // Empty string preserved as just a semicolon
+      'font-size: 16px;',
+    ]);
+  });
+
+  it('uses custom indentation and prefix', () => {
+    const rules: CSSRules[] = [
+      { color: 'red' },
+      { fontSize: '16px' },
+    ];
+
+    const options: CSSRulesFormatOptions = {
+      indent: '  ',
+      prefix: '• ',
+    };
+
+    const result = formatCSSRulesArray(rules, options);
+
+    expect(result).toEqual([
+      '• color: red;',
+      '• fontSize: 16px;',
+    ]);
+  });
+
+  it('handles nested arrays', () => {
+    const rules: (string | CSSRules)[] = [
+      'color: red',
+      {
+        '.nested': {
+          fontSize: '12px',
+        },
+      },
+    ];
+
+    const result = formatCSSRulesArray(rules);
+
+    expect(result).toEqual([
+      'color: red;',
+      '.nested {',
+      '  fontSize: 12px;',
+      '}',
+    ]);
+  });
+});
+
+describe('defaultValidCSSRule', () => {
+  it('accepts valid rules', () => {
+    expect(defaultValidCSSRule('color', 'red')).toBe(true);
+    expect(defaultValidCSSRule('fontSize', '12')).toBe(true);
+    expect(defaultValidCSSRule('margin', ['10px', '20px'])).toBe(true);
+    expect(defaultValidCSSRule('child', { color: 'blue' })).toBe(true);
+  });
+
+  it('rejects empty keys', () => {
+    expect(defaultValidCSSRule('', 'value')).toBe(false);
+  });
+
+  it('rejects null values', () => {
+    // eslint-disable-next-line unicorn/no-null
+    expect(defaultValidCSSRule('color', null)).toBe(false);
+  });
+
+  it('rejects undefined values', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(defaultValidCSSRule('color', undefined as any)).toBe(false);
+  });
+});
+
+describe('at-rule handling', () => {
+  it('preserves empty at-rules', () => {
+    const rules: CSSRules = {
+      '@supports (display: grid)': {},
+      '@media print': [],
+      '@charset': 'utf8',
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    expect(result).toContain('@supports (display: grid);');
+    expect(result).toContain('@media print;');
+    expect(result).toContain('@charset: utf8;');
+  });
+
+  it('properly formats non-empty at-rules', () => {
+    const rules: CSSRules = {
+      '@media (max-width: 768px)': {
+        '.container': {
+          fontSize: '14px',
+        },
+      },
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    expect(result).toContain('@media (max-width: 768px) {');
+    expect(result).toContain('.container {');
+    expect(result).toContain('fontSize: 14px;');
+    expect(result).not.toContain('@media (max-width: 768px);'); // Should not be treated as empty
+  });
+
+  it('filters out null at-rules', () => {
+    const rules: CSSRules = {
+      '@import': 'url("styles.css")',
+      // eslint-disable-next-line unicorn/no-null
+      '@namespace': null,
+    };
+
+    const result = stringifyCSSRules(rules);
+
+    expect(result).toContain('@import: url("styles.css");');
+    expect(result).not.toContain('@namespace');
+  });
+});

--- a/packages/@poupe-css/src/rules.ts
+++ b/packages/@poupe-css/src/rules.ts
@@ -1,0 +1,268 @@
+import {
+  pairs,
+} from './utils';
+
+import {
+  formatCSSValue,
+  spaceDelimitedProperties,
+} from './properties';
+
+/**
+ * Represents a structured CSS rule set that can contain nested rules.
+ *
+ * This type allows for representing complex CSS structures including:
+ * - Simple property/value pairs
+ * - At-rules (like `@media`, `@keyframes`)
+ * - Nested rule sets
+ * - Arrays of values or rule sets
+ *
+ * @example
+ * ```
+ * // Example CSS rule structure
+ * const rules = {
+ *   body: {
+ *     color: 'red',
+ *     fontSize: '16px',
+ *     '@media (max-width: 768px)': {
+ *       fontSize: '14px'
+ *     }
+ *   }
+ * };
+ * ```
+ */
+export type CSSRules = {
+  [name: string]: null | string | string[] | CSSRules | CSSRules[]
+};
+
+/**
+ * Represents the possible value types that can be assigned to a CSS rule.
+ *
+ * This is a type alias for the union of all possible values in a CSSRules object.
+ */
+export type CSSRulesValue = CSSRules[string];
+
+/**
+ * Configuration options for formatting CSS rules.
+ */
+export interface CSSRulesFormatOptions {
+  /**
+   * Indentation string to use for each level of nesting.
+   * @defaultValue `'  '` (two spaces)
+   */
+  indent?: string
+
+  /**
+   * Prefix string added before each line.
+   * @defaultValue `''` (empty string)
+   */
+  prefix?: string
+
+  /**
+   * Optional validation function to determine which rules to include.
+   * @param key - The rule name/selector
+   * @param value - The rule value
+   * @returns `true` if the rule should be included, `false` otherwise
+   */
+  valid?: (key: string, value: CSSRulesValue) => boolean
+}
+
+/**
+ * A subset of CSSRules that is compatible with tailwindcss plugin API.
+ *
+ * This type is more restrictive than CSSRules:
+ * - It doesn't allow null values
+ * - It uses itself for nested rules rather than the broader CSSRules type
+ */
+export type CSSRuleObject = {
+  [key: string]: string | string[] | CSSRuleObject
+};
+
+/**
+ * Converts a CSS rule object into a formatted string representation.
+ *
+ * This function takes a CSS rule object and returns a formatted string with
+ * proper indentation and nesting.
+ *
+ * @param rules - The CSS rules to stringify
+ * @param options - Configuration options for string formatting
+ * @returns A string representing the CSS rules with proper formatting
+ *
+ * @example
+ * ```
+ * // Simple example of stringifying CSS rules
+ * const rules = {
+ *   'body': {
+ *     'color': 'red',
+ *     'font-size': '16px'
+ *   }
+ * };
+ *
+ * const result = stringifyCSSRules(rules);
+ * // Result will be:
+ * // body {
+ * //   color: red;
+ * //   font-size: 16px;
+ * // };
+ * ```
+ *
+ */
+export function stringifyCSSRules(
+  rules: CSSRules | CSSRuleObject = {},
+  options: CSSRulesFormatOptions & {
+    /**
+     * Character(s) to use for line breaks.
+     * @defaultValue `'\n'`
+     */
+    newLine?: string
+  } = {}): string {
+  const {
+    newLine = '\n',
+  } = options;
+
+  return formatCSSRules(rules, options).join(newLine);
+}
+
+/**
+ * Formats CSS rule objects into an array of formatted lines.
+ *
+ * This function processes a CSS rule object and returns an array of strings,
+ * where each string represents a line in the formatted CSS output. It handles
+ * various value types including strings, numbers, arrays, and nested objects.
+ *
+ * @param rules - The CSS rules to format
+ * @param options - Configuration options for formatting
+ * @returns An array of strings, each representing a line in the formatted CSS
+ *
+ * @example
+ * ```
+ * const rules = {
+ *   'body': {
+ *     'color': 'red'
+ *   }
+ * };
+ *
+ * const lines = formatCSSRules(rules);
+ * // Returns: ['body {', '  color: red;', '}']
+ * ```
+ *
+ */
+export function formatCSSRules(rules: CSSRules | CSSRuleObject = {}, options: CSSRulesFormatOptions = {}): string[] {
+  const {
+    indent = '  ',
+    prefix = '',
+    valid = defaultValidCSSRule,
+  } = options;
+
+  const out: string[] = [];
+  const nextOptions: CSSRulesFormatOptions = {
+    ...options,
+    prefix: prefix + indent,
+  };
+
+  for (const [key, value] of pairs(rules, valid)) {
+    if (atRuleException(key, value)) {
+      // at-function
+      out.push(`${prefix}${key};`);
+    } else if (typeof value === 'number') {
+      out.push(`${prefix}${key}: ${value};`);
+    } else if (typeof value === 'string') {
+      // string, omit empty.
+      if (value) {
+        out.push(`${prefix}${key}: ${value};`);
+      }
+    } else if (Array.isArray(value)) {
+      if (value.length === 0) {
+        continue;
+      } else if (typeof value[0] === 'string') {
+        // multi-value
+        const useComma = !spaceDelimitedProperties.has(key);
+        const inner = formatCSSValue(value as string[], useComma);
+        if (inner) {
+          out.push(`${prefix}${key}: ${inner};`);
+        }
+      } else {
+        // nested, omit empty
+        const inner = formatCSSRulesArray(value, nextOptions);
+        if (inner) {
+          out.push(`${prefix}${key} {`, ...inner, `${prefix}}`);
+        }
+      }
+    } else if (value) {
+      // nested, omit empty
+      const inner = formatCSSRules(value, nextOptions);
+      if (inner) {
+        out.push(`${prefix}${key} {`, ...inner, `${prefix}}`);
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Formats an array of CSS rules into indented lines recursively.
+ *
+ * This function handles arrays of strings or nested rule objects and formats them
+ * into an array of lines for output.
+ *
+ * @param rules - The array of CSS rules to format
+ * @param options - Configuration options for formatting
+ * @returns An array of strings, each representing a line in the formatted CSS
+ */
+export function formatCSSRulesArray(rules: (string | CSSRules | CSSRuleObject)[] = [], options: CSSRulesFormatOptions = {}): string[] {
+  const out: string[] = [];
+
+  for (const value of rules) {
+    if (typeof value === 'string') {
+      // string, preserve empty for whitespace.
+      if (value || out.length > 0) {
+        out.push(value ? `${value};` : '');
+      }
+    } else {
+      // object
+      out.push(...formatCSSRules(value, options));
+    }
+  }
+  return out;
+}
+
+/**
+ * Default validation function for CSS rules.
+ *
+ * Determines if a CSS rule key-value pair should be included in the output.
+ * By default, a rule is valid if:
+ * - The key is not an empty string
+ * - The value is neither undefined nor null
+ *
+ * @param key - The rule key/selector to validate
+ * @param value - The rule value to validate
+ * @returns `true` if the rule should be included, `false` otherwise
+ */
+export function defaultValidCSSRule(key: string, value: CSSRulesValue): boolean {
+  if (key === '' || value === undefined || value === null) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Special handling for CSS at-rules with empty content.
+ *
+ * At-rules (rules starting with `@`) with empty content are treated differently:
+ * - Empty at-rules (like `@import`, `@charset`) are rendered as a single line with semicolon
+ * - Normal CSS rules with empty content would be omitted entirely
+ *
+ * @example
+ * `@supports (display: grid) {}` becomes `@supports (display: grid);`
+ */
+function atRuleException(key: string, value: CSSRulesValue): boolean {
+  if (!key.startsWith('@') || value === null) {
+    return false;
+  } else if (Array.isArray(value)) {
+    return value.length === 0;
+  } else if (typeof value === 'object') {
+    return Object.keys(value).length === 0;
+  } else {
+    return false;
+  }
+}

--- a/packages/@poupe-css/src/utils.test.ts
+++ b/packages/@poupe-css/src/utils.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/no-null */
 /* eslint-disable unicorn/consistent-function-scoping */
 import { describe, it, expect } from 'vitest';
-import { defaultValidPair, pairs, kebabCase, unsafeKeys, keys } from './utils';
+import { camelCase, defaultValidPair, kebabCase, keys, pairs, unsafeKeys } from './utils';
 
 describe('defaultValidPair', () => {
   it('returns true for valid key-value pairs', () => {
@@ -117,6 +117,62 @@ describe('kebabCase', () => {
     expect(kebabCase('WebkitTapHighlightColor')).toBe('-webkit-tap-highlight-color');
     expect(kebabCase('MozOsxFontSmoothing')).toBe('-moz-osx-font-smoothing');
     expect(kebabCase('MsImeAlign')).toBe('-ms-ime-align');
+  });
+});
+
+describe('camelCase', () => {
+  it('converts kebab-case to camelCase', () => {
+    expect(camelCase('kebab-case')).toBe('kebabCase');
+    expect(camelCase('multiple-words-here')).toBe('multipleWordsHere');
+  });
+
+  it('converts PascalCase to camelCase', () => {
+    expect(camelCase('PascalCase')).toBe('pascalCase');
+    expect(camelCase('HTMLElement')).toBe('htmlElement');
+  });
+
+  it('converts snake_case to camelCase', () => {
+    expect(camelCase('snake_case')).toBe('snakeCase');
+    expect(camelCase('multiple_words_here')).toBe('multipleWordsHere');
+  });
+
+  it('handles spaces correctly', () => {
+    expect(camelCase('with spaces')).toBe('withSpaces');
+    expect(camelCase('  multiple  spaces  ')).toBe('multipleSpaces');
+  });
+
+  it('handles multiple uppercase letters correctly', () => {
+    expect(camelCase('XML-http-request')).toBe('xmlHttpRequest');
+    expect(camelCase('BGColor')).toBe('bgColor');
+  });
+
+  it('handles vendor prefixes correctly', () => {
+    expect(camelCase('-webkit-transition')).toBe('webkitTransition');
+    expect(camelCase('-moz-border-radius')).toBe('mozBorderRadius');
+    expect(camelCase('-ms-flexbox')).toBe('msFlexbox');
+    expect(camelCase('-o-animation')).toBe('oAnimation');
+    expect(camelCase('-khtml-user-select')).toBe('khtmlUserSelect');
+  });
+
+  it('handles complex vendor prefixed properties', () => {
+    expect(camelCase('-webkit-tap-highlight-color')).toBe('webkitTapHighlightColor');
+    expect(camelCase('-moz-osx-font-smoothing')).toBe('mozOsxFontSmoothing');
+  });
+
+  it('preserves already camelCase strings', () => {
+    expect(camelCase('alreadyCamel')).toBe('alreadyCamel');
+    expect(camelCase('anotherCamelCase')).toBe('anotherCamelCase');
+  });
+
+  it('handles multiple delimiters', () => {
+    expect(camelCase('mix-of_different delimiters')).toBe('mixOfDifferentDelimiters');
+    expect(camelCase('multiple--hyphens__underscores')).toBe('multipleHyphensUnderscores');
+  });
+
+  it('handles empty strings and edge cases', () => {
+    expect(camelCase('')).toBe('');
+    expect(camelCase('-')).toBe('');
+    expect(camelCase('_')).toBe('');
   });
 });
 

--- a/packages/@poupe-css/src/utils.ts
+++ b/packages/@poupe-css/src/utils.ts
@@ -53,14 +53,14 @@ export function defaultValidPair<K extends string, T = unknown>(key: K, value: T
  * @param valid - Optional validation function that determines which key-value pairs to yield
  * @returns A generator of valid key-value pairs from the object
  */
-export function* pairs<K extends string = string, T1 = unknown, T2 = unknown>(
-  object: Record<K, T1>,
-  valid?: (k: K, v: T1) => boolean,
-): Generator<[K, T2]> {
+export function* pairs<K extends string = string, T = unknown>(
+  object: Record<K, T>,
+  valid?: (k: K, v: T) => boolean,
+): Generator<[K, T]> {
   for (const key of keys(object)) {
     const value = object[key];
     if (valid?.(key, value) ?? defaultValidPair(key, value))
-      yield [key, value as unknown as T2];
+      yield [key, value];
   }
 }
 

--- a/packages/@poupe-css/src/utils.ts
+++ b/packages/@poupe-css/src/utils.ts
@@ -101,3 +101,47 @@ export function kebabCase(s: string): string {
 }
 
 const vendorPrefixPattern = /^(webkit|moz|ms|o|khtml)-/;
+
+/**
+ * Converts a given string to camelCase.
+ *
+ * Transforms various string formats (kebab-case, PascalCase, snake_case)
+ * into a camelCase string. Properly handles vendor prefixes and internal
+ * capitalization patterns.
+ *
+ * @param s - The input string to convert
+ * @returns A camelCase representation of the input string
+ *
+ * @example
+ * camelCase('xml-http-request') // returns 'xmlHttpRequest'
+ * camelCase('PascalCase') // returns 'pascalCase'
+ * camelCase('snake_case') // returns 'snakeCase'
+ * camelCase('-webkit-transition') // returns 'webkitTransition'
+ * camelCase('BGColor') // returns 'bgColor'
+ * camelCase('HTMLElement') // returns 'htmlElement'
+ */
+export function camelCase(s: string): string {
+  // Handle empty strings and single delimiters
+  if (!s || s === '-' || s === '_') {
+    return '';
+  }
+
+  // Remove leading hyphens (for vendor prefixes) and trim
+  let result = s.trim().replace(/^-/, '');
+
+  // Handle explicit delimiter-separated words (kebab-case, snake_case, spaces)
+  result = result.replaceAll(/[-_\s]+([\w])/g, (_, c) => c.toUpperCase());
+
+  // Handle internal capitalization patterns like "BGColor" -> "bgColor"
+  // Look for uppercase letters that are preceded by lowercase or are the start
+  // of a capital sequence followed by lowercase (like in "BGColor" or "HTMLElement")
+  result = result
+    // First handle patterns like "BGColor" by preserving the capital letter after
+    // a sequence of capitals
+    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, (_, g1, g2) => g1.toLowerCase() + g2)
+    // Then ensure the first letter is lowercase (handling both PascalCase and
+    // cases like "BG" at the start)
+    .replaceAll(/^[A-Z]+/g, match => match.toLowerCase());
+
+  return result;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced utilities for handling and formatting nested CSS rules, including functions to convert CSS rule objects into formatted strings and arrays.
  - Added support for camelCase conversion of CSS property names, with comprehensive handling of various naming styles and vendor prefixes.

- **Enhancements**
  - Improved formatting options for CSS property values, supporting both space- and comma-delimited arrays, and enhanced handling of quoting and boolean values.
  - Expanded and reorganized documentation with detailed usage examples, type definitions, and a new section on CSS rules functions.

- **Bug Fixes**
  - Corrected formatting logic for space-delimited CSS properties to ensure proper output in all scenarios.

- **Tests**
  - Added extensive tests for new CSS rules formatting utilities and camelCase conversion.
  - Expanded tests for CSS property formatting, including delimiter and quoting rules.

- **Chores**
  - Updated package metadata, including version bump, keywords, and links for improved discoverability and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->