### PR TITLE
feat(poupe-css): introduce CSSRules helpers and improve spacing when formatting

### DIFF
--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -162,7 +162,7 @@ const cssLines = formatCSSProperties(styles);
 // [
 //   "font-size: 16px",
 //   "background-color: blue", // Note: red was overridden by blue
-//   "margin: 10, 20px, 30px, 40px"
+//   "margin: 10, 20px, 30px"
 // ]
 ```
 
@@ -298,6 +298,63 @@ import { defaultValidCSSRule } from '@poupe/css';
 const customValid = (key, value) => {
   return defaultValidCSSRule(key, value) && !key.startsWith('_');
 };
+```
+
+#### `interleavedRules(rules: CSSRules[]): CSSRules[]`
+Interleaves an array of CSS rule objects with empty objects, useful for creating spacing between rule blocks in the output.
+
+```typescript
+import { interleavedRules } from '@poupe/css';
+
+const rules = [
+  { '.button': { color: 'blue' } },
+  { '.input': { border: '1px solid gray' } }
+];
+
+const spacedRules = interleavedRules(rules);
+// Returns:
+// [
+//   { '.button': { color: 'blue' } },
+//   {}, // Empty object for spacing
+//   { '.input': { border: '1px solid gray' } }
+// ]
+
+// When stringified, this creates an empty line between rule blocks
+```
+
+#### `renameRules(rules: CSSRules, fn: (name: string) => string): CSSRules`
+Renames the keys in a CSS rules object using the provided function, allowing for advanced selector manipulation.
+
+```typescript
+import { renameRules } from '@poupe/css';
+
+const rules = {
+  '.button': { color: 'blue' },
+  '.input': { border: '1px solid gray' }
+};
+
+// Add a prefix to all selectors
+const prefixedRules = renameRules(rules, key => `.prefix ${key}`);
+// Returns:
+// {
+//   '.prefix .button': { color: 'blue' },
+//   '.prefix .input': { border: '1px solid gray' }
+// }
+
+// Transform selectors to utility classes
+const utilityRules = renameRules(rules, key => `@utility ${key.slice(1)}`);
+// Returns:
+// {
+//   '@utility button': { color: 'blue' },
+//   '@utility input': { border: '1px solid gray' }
+// }
+
+// Return falsy from the function to skip/remove a rule
+const filteredRules = renameRules(rules, key => key.includes('button') ? key : null);
+// Returns:
+// {
+//   '.button': { color: 'blue' }
+// }
 ```
 
 ### Utility Functions

--- a/packages/@poupe-css/package.json
+++ b/packages/@poupe-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/css",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "A TypeScript utility library for CSS property manipulation, formatting, and CSS-in-JS operations",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-css/src/index.ts
+++ b/packages/@poupe-css/src/index.ts
@@ -12,12 +12,14 @@ export {
 export {
   type CSSRuleObject,
   type CSSRules,
-  type CSSRulesValue,
   type CSSRulesFormatOptions,
-  stringifyCSSRules,
+  type CSSRulesValue,
+  defaultValidCSSRule,
   formatCSSRules,
   formatCSSRulesArray,
-  defaultValidCSSRule,
+  interleavedRules,
+  renameRules,
+  stringifyCSSRules,
 } from './rules';
 
 export {

--- a/packages/@poupe-css/src/rules.ts
+++ b/packages/@poupe-css/src/rules.ts
@@ -266,3 +266,55 @@ function atRuleException(key: string, value: CSSRulesValue): boolean {
     return false;
   }
 }
+
+/**
+ * Interleaves an array of CSS rule objects with empty objects.
+ *
+ * @param rules - An array of CSS rule objects to be interleaved
+ * @returns An array with the original rules spaced out with empty objects
+ *
+ * @example
+ * ```
+ * // Input: [{ color: 'red' }, { background: 'blue' }]
+ * // Output: [{ color: 'red' }, {}, { background: 'blue' }]
+ * ```
+ */
+export function interleavedRules(rules: CSSRules[]): CSSRules[] {
+  if (rules.length === 0) return [];
+
+  const size = rules.length * 2 - 1;
+  const out: Array<CSSRules> = Array.from({ length: size }, () => ({}));
+
+  let i = 0;
+  for (const entry of rules) {
+    out[i] = entry;
+    i += 2;
+  }
+
+  return out;
+}
+
+/**
+ * Renames the keys in a CSS rules object using the provided function.
+ *
+ * @param rules - The CSS rules object whose keys should be renamed
+ * @param fn - A function that takes an original key name and returns a new key name (or falsy value to skip)
+ * @returns A new CSS rules object with renamed keys
+ *
+ * @example
+ * ```
+ * // Input: { '.button': { color: 'blue' } }, key => `@utility ${key.slice(1)}`
+ * // Output: { '@utility button': { color: 'blue' } }
+ * ```
+ */
+export function renameRules(rules: CSSRules, fn: (name: string) => string): CSSRules {
+  if (!fn) return rules;
+
+  const map = new Map<string, CSSRules[string]>();
+  for (const [key, value] of pairs(rules)) {
+    const k2 = fn(key);
+    if (k2) map.set(k2, value);
+  }
+
+  return Object.fromEntries(map);
+}

--- a/packages/@poupe-css/src/rules.ts
+++ b/packages/@poupe-css/src/rules.ts
@@ -200,29 +200,63 @@ export function formatCSSRules(rules: CSSRules | CSSRuleObject = {}, options: CS
 }
 
 /**
- * Formats an array of CSS rules into indented lines recursively.
+ * Formats an array of CSS rules into an array of formatted string lines.
  *
- * This function handles arrays of strings or nested rule objects and formats them
- * into an array of lines for output.
+ * This function processes various CSS rule representations recursively and converts them
+ * into strings representing CSS code with proper formatting. It handles:
  *
- * @param rules - The array of CSS rules to format
+ * - String values (treated as direct CSS with semicolons added)
+ * - Empty strings (converted to blank lines for spacing if appropriate)
+ * - CSS rule objects (recursively processed with formatCSSRules)
+ * - Empty rule objects (possibly generating blank lines)
+ *
+ * The function maintains proper whitespace by tracking whether the last inserted
+ * item was a blank line to avoid consecutive empty lines.
+ *
+ * @param rules - The array of CSS rules to format (strings or rule objects)
  * @param options - Configuration options for formatting
  * @returns An array of strings, each representing a line in the formatted CSS
+ *
+ * @example
+ * ```
+ * // Mixed strings and objects
+ * formatCSSRulesArray([
+ *   'display: block',
+ *   { color: 'red' },
+ *   '',
+ *   { fontSize: '16px' }
+ * ]);
+ * // Returns: ['display: block;', 'color: red;', '', 'fontSize: 16px;']
+ * ```
  */
 export function formatCSSRulesArray(rules: (string | CSSRules | CSSRuleObject)[] = [], options: CSSRulesFormatOptions = {}): string[] {
   const out: string[] = [];
 
+  // track if the last item was a blank line, to avoid consecutive empty lines.
+  let first = true;
   for (const value of rules) {
     if (typeof value === 'string') {
       // string, preserve empty for whitespace.
-      if (value || out.length > 0) {
-        out.push(value ? `${value};` : '');
+      if (value) {
+        out.push(`${value};`);
+        first = false;
+      } else if (!first) {
+        out.push('');
+        first = true;
       }
-    } else {
+    } else if (value !== null && value !== undefined) {
       // object
-      out.push(...formatCSSRules(value, options));
+      const entries = value ? formatCSSRules(value, options) : [];
+      if (entries.length > 0) {
+        out.push(...entries);
+        first = false;
+      } else if (!first) {
+        out.push('');
+        first = true;
+      }
     }
   }
+
   return out;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced two new utility functions for CSS rule manipulation: one for interleaving empty objects between rule blocks, and another for renaming rule keys via a custom function.
- **Documentation**
  - Updated the documentation to include detailed descriptions and usage examples for the new utility functions.
- **Tests**
  - Added comprehensive tests to ensure correct behavior of the new utilities and improved formatting logic.
- **Chores**
  - Incremented the package version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->