### PR TITLE
feat(poupe-tailwindcss): make validShade and makeShades public, introduce makeHexShades and rewrite README.md

### DIFF
--- a/packages/@poupe-tailwindcss/README.md
+++ b/packages/@poupe-tailwindcss/README.md
@@ -4,7 +4,23 @@
 [![npm version](https://img.shields.io/npm/v/@poupe/tailwindcss.svg)](https://www.npmjs.com/package/@poupe/tailwindcss)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENCE.txt)
 
-TailwindCSS v4 plugin for Poupe UI framework with theme customization support.
+A TypeScript plugin for TailwindCSS v4 that integrates with the Poupe UI
+framework, providing theme customization and utility functions.
+
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Basic Configuration](#basic-configuration)
+  - [Advanced Theme Integration](#advanced-theme-integration)
+- [API Reference](#api-reference)
+  - [Main Plugin](#main-plugin)
+  - [Theme Utilities](#theme-utilities)
+  - [Helper Functions](#helper-functions)
+- [Integration with Poupe Ecosystem](#integration-with-poupe-ecosystem)
+- [Requirements](#requirements)
+- [License](#license)
 
 ## Features
 
@@ -12,23 +28,31 @@ TailwindCSS v4 plugin for Poupe UI framework with theme customization support.
 - 🎨 Automatic generation of TailwindCSS theme from Poupe tokens
 - 🌓 Dark mode support built-in
 - 🛠️ Utility functions for consistent styling
+- 📦 Lightweight, tree-shakable API
+- 🧩 Component-friendly design tokens
 
 ## Installation
 
 ```bash
-npm install @poupe/tailwindcss @poupe/theme-builder
-# or
-yarn add @poupe/tailwindcss @poupe/theme-builder
-# or
-pnpm add @poupe/tailwindcss @poupe/theme-builder
+npm install -D @poupe/tailwindcss @poupe/theme-builder
+```
+
+```bash
+yarn add -D @poupe/tailwindcss @poupe/theme-builder
+```
+
+```bash
+pnpm add -D @poupe/tailwindcss @poupe/theme-builder
 ```
 
 ## Usage
 
-### In your tailwind.config.js
+### Basic Configuration
 
-```javascript
-import { poupePlugin } from '@poupe/tailwindcss'
+In your `tailwind.config.js` or `tailwind.config.ts` file:
+
+```typescript
+import { themePlugin as poupePlugin } from '@poupe/tailwindcss'
 
 export default {
   content: [
@@ -49,9 +73,11 @@ export default {
 }
 ```
 
-### Using the theme utilities
+### Advanced Theme Integration
 
-```javascript
+For more advanced usage, you can create and customize themes separately:
+
+```typescript
 import { createTailwindTheme } from '@poupe/tailwindcss/theme'
 import { createTheme } from '@poupe/theme-builder'
 
@@ -59,6 +85,7 @@ import { createTheme } from '@poupe/theme-builder'
 const myTheme = createTheme({
   colors: {
     primary: '#1976d2',
+    secondary: '#9c27b0',
     // ...more colors
   }
 })
@@ -73,26 +100,59 @@ export default {
 }
 ```
 
-## Exports
+## API Reference
 
-- **Main Export**: TailwindCSS plugin
-- **Theme**: Theme generation utilities
-- **Utils**: Helper functions
+The library exports several modules for different use cases:
 
-## Integration
+### Main Plugin
 
-This package integrates well with the following Poupe packages:
+```typescript
+import { themePlugin } from '@poupe/tailwindcss'
+```
 
-- [@poupe/css](../@poupe-css) - CSS-in-JS utilities
-- [@poupe/theme-builder](../@poupe-theme-builder) - Theme token generation
+The main plugin that integrates Poupe theme tokens with TailwindCSS. It
+automatically generates color variants, shadows, typography scales, and component
+utilities based on your theme configuration.
+
+### Theme Utilities
+
+```typescript
+import { createTheme } from '@poupe/tailwindcss/theme'
+```
+
+Utilities for converting Poupe themes to TailwindCSS compatible themes,
+including:
+
+- Color shade generation
+- Typography scaling
+- Spacing and sizing adaptations
+- Component-specific tokens
+
+### Helper Functions
+
+```typescript
+import { getShades, validShade } from '@poupe/tailwindcss/theme'
+```
+
+Helper functions for:
+
+- Working with color shades
+- Validating theme options
+- Type checking utility functions
+- Debugging and logging tools
+
+## Integration with Poupe Ecosystem
+
+- [@poupe/css](../@poupe-css) - CSS utility library
+- [@poupe/theme-builder](../@poupe-theme-builder) - Design tokens generation
 - [@poupe/vue](../@poupe-vue) - Vue components library
 - [@poupe/nuxt](../@poupe-nuxt) - Nuxt integration
 
 ## Requirements
 
 - Node.js >=20.19.1
-- TailwindCSS ^4.1.6
-- @poupe/theme-builder ^0.7.0
+- TailwindCSS ^4.1.7
+- @poupe/theme-builder ^0.8.0
 
 ## License
 

--- a/packages/@poupe-tailwindcss/package.json
+++ b/packages/@poupe-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/tailwindcss",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "description": "TailwindCSS v4 plugin for Poupe UI framework with theme customization support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-tailwindcss/src/index.ts
+++ b/packages/@poupe-tailwindcss/src/index.ts
@@ -7,5 +7,5 @@ export {
 export {
   type ThemeOptions,
 
-  themePlugin as createPlugin,
+  themePlugin,
 } from './theme/index';

--- a/packages/@poupe-tailwindcss/src/theme/__tests__/shades.test.ts
+++ b/packages/@poupe-tailwindcss/src/theme/__tests__/shades.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/consistent-function-scoping */
 import { describe, it, expect } from 'vitest';
 
 import {
@@ -155,12 +156,15 @@ describe('shades utilities', () => {
       expect(uniqueHexValues.size).toBe(hexValues.length);
 
       // 100 should be lighter than 500, and 900 should be darker
-      // eslint-disable-next-line unicorn/consistent-function-scoping
       const isLighter = (hex1: string, hex2: string) => {
-        // Simple lightness comparison - sum of RGB values
-        const sum1 = Number.parseInt(hex1.slice(1, 3), 16) + Number.parseInt(hex1.slice(3, 5), 16) + Number.parseInt(hex1.slice(5, 7), 16);
-        const sum2 = Number.parseInt(hex2.slice(1, 3), 16) + Number.parseInt(hex2.slice(3, 5), 16) + Number.parseInt(hex2.slice(5, 7), 16);
-        return sum1 > sum2;
+        // Using weighted RGB for better perceptual comparison (human eyes are more sensitive to green)
+        const getWeightedLightness = (hex: string) => {
+          const r = Number.parseInt(hex.slice(1, 3), 16);
+          const g = Number.parseInt(hex.slice(3, 5), 16);
+          const b = Number.parseInt(hex.slice(5, 7), 16);
+          return 0.299 * r + 0.587 * g + 0.114 * b; // Standard luminance formula
+        };
+        return getWeightedLightness(hex1) > getWeightedLightness(hex2);
       };
 
       expect(isLighter(result![100], result![500])).toBe(true);

--- a/packages/@poupe-tailwindcss/src/theme/__tests__/shades.test.ts
+++ b/packages/@poupe-tailwindcss/src/theme/__tests__/shades.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  defaultShades,
+  getShades,
+  makeHexShades,
+  makeShades,
+  validShade,
+} from '../shades';
+
+import { hct } from '@poupe/theme-builder/core';
+
+describe('shades utilities', () => {
+  describe('validShade', () => {
+    it('returns true for valid shade values', () => {
+      expect(validShade(50)).toBe(true);
+      expect(validShade(100)).toBe(true);
+      expect(validShade(950)).toBe(true);
+      expect(validShade(999)).toBe(true);
+    });
+
+    it('returns false for invalid shade values', () => {
+      expect(validShade(0)).toBe(false);
+      expect(validShade(1000)).toBe(false);
+      expect(validShade(-100)).toBe(false);
+      expect(validShade(100.5)).toBe(false);
+    });
+  });
+
+  describe('getShades', () => {
+    it('returns default shades when input is true or undefined', () => {
+      expect(getShades(true).shades).toEqual(defaultShades);
+      expect(getShades().shades).toEqual(defaultShades);
+    });
+
+    it('returns false when input is false', () => {
+      expect(getShades(false).shades).toBe(false);
+    });
+
+    it('returns custom shades when array is provided', () => {
+      expect(getShades([100, 300, 500]).shades).toEqual([100, 300, 500]);
+    });
+
+    it('handles negative values as append mode', () => {
+      const expectedSet = new Set([...defaultShades, 100, 300]);
+      expect(getShades([-100, -300]).shades).toEqual([...expectedSet].sort((a, b) => a - b));
+    });
+
+    it('sorts shades in ascending order', () => {
+      expect(getShades([500, 100, 900]).shades).toEqual([100, 500, 900]);
+    });
+
+    it('removes duplicate shades', () => {
+      expect(getShades([100, 100, 500, 500]).shades).toEqual([100, 500]);
+    });
+
+    it('returns error for invalid shade values', () => {
+      const result = getShades([0, 100, 1000]);
+      expect(result.shades).toBe(false);
+      expect(result.ok).toBe(false);
+    });
+
+    it('returns error for empty shade array', () => {
+      const result = getShades([]);
+      expect(result.shades).toBe(false);
+      expect(result.ok).toBe(false);
+    });
+
+    it('returns error for non-array, non-boolean input', () => {
+      // @ts-expect-error Testing invalid input
+      const result = getShades('invalid');
+      expect(result.shades).toBe(false);
+      expect(result.ok).toBe(false);
+    });
+
+    it('uses provided defaults when specified', () => {
+      const customDefaults = [200, 400, 600, 800];
+      expect(getShades(undefined, customDefaults).shades).toEqual(customDefaults);
+      expect(getShades([-100], customDefaults).shades).toEqual([100, 200, 400, 600, 800]);
+    });
+  });
+
+  describe('makeShades', () => {
+    const testColor = hct('#0047AB'); // Royal Blue
+
+    it('returns undefined when shades is false', () => {
+      expect(makeShades(testColor, false)).toBeUndefined();
+    });
+
+    it('maps out of range shade values to white or black', () => {
+      const shades = makeShades(testColor, [0, 2000]);
+      expect(shades).toBeDefined();
+      // Shade 0 should be white (tone 100)
+      expect(shades![0].tone).toBeCloseTo(100, 0);
+      // Shade 2000 should be black (tone 0)
+      expect(shades![2000].tone).toBeCloseTo(0, 0);
+    });
+
+    it('generates Hct colors for valid shades', () => {
+      const shades = makeShades(testColor, [100, 500, 900]);
+
+      expect(shades).toBeDefined();
+      expect(Object.keys(shades!).length).toBe(3);
+      expect(shades![100]).toBeDefined();
+      expect(shades![500]).toBeDefined();
+      expect(shades![900]).toBeDefined();
+
+      // Verify colors have same hue but different tones
+      const h100 = shades![100].hue;
+      const h500 = shades![500].hue;
+      const h900 = shades![900].hue;
+
+      expect(h100).toBeCloseTo(h500, 0);
+      expect(h500).toBeCloseTo(h900, 0);
+
+      // Verify tones follow expected pattern (higher shade = lower tone)
+      expect(shades![100].tone).toBeGreaterThan(shades![500].tone);
+      expect(shades![500].tone).toBeGreaterThan(shades![900].tone);
+    });
+  });
+
+  describe('makeHexShades', () => {
+    const testColor = '#0047AB'; // Royal Blue
+
+    it('returns undefined when shades is false', () => {
+      expect(makeHexShades(testColor, false)).toBeUndefined();
+    });
+
+    it('uses default shades when none provided', () => {
+      const result = makeHexShades(testColor);
+      expect(result).toBeDefined();
+      expect(Object.keys(result!).length).toBe(defaultShades.length);
+
+      // Check that all default shades exist
+      for (const shade of defaultShades) {
+        expect(result![shade]).toBeDefined();
+      }
+    });
+
+    it('generates hex color strings for each shade', () => {
+      const result = makeHexShades(testColor, [100, 500, 900]);
+
+      expect(result).toBeDefined();
+      expect(Object.keys(result!).length).toBe(3);
+
+      // Verify hex format
+      const hexRegex = /^#[0-9A-F]{6}$/i;
+      expect(result![100]).toMatch(hexRegex);
+      expect(result![500]).toMatch(hexRegex);
+      expect(result![900]).toMatch(hexRegex);
+
+      // Check that all generated shades are different
+      const hexValues = Object.values(result!);
+      const uniqueHexValues = new Set(hexValues);
+      expect(uniqueHexValues.size).toBe(hexValues.length);
+
+      // 100 should be lighter than 500, and 900 should be darker
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const isLighter = (hex1: string, hex2: string) => {
+        // Simple lightness comparison - sum of RGB values
+        const sum1 = Number.parseInt(hex1.slice(1, 3), 16) + Number.parseInt(hex1.slice(3, 5), 16) + Number.parseInt(hex1.slice(5, 7), 16);
+        const sum2 = Number.parseInt(hex2.slice(1, 3), 16) + Number.parseInt(hex2.slice(3, 5), 16) + Number.parseInt(hex2.slice(5, 7), 16);
+        return sum1 > sum2;
+      };
+
+      expect(isLighter(result![100], result![500])).toBe(true);
+      expect(isLighter(result![500], result![900])).toBe(true);
+    });
+  });
+
+  describe('toTone function', () => {
+    // toTone is a private function, so we can test it indirectly through makeShades
+    it('converts shade to correct tone value', () => {
+      const testColor = hct('#0047AB');
+      const shades = makeShades(testColor, [50, 500, 950]);
+
+      // Verify tone values: toTone(shade) = (1000 - shade) / 10
+      expect(shades![50].tone).toBeCloseTo(95, 1); // (1000 - 50) / 10 = 95
+      expect(shades![500].tone).toBeCloseTo(50, 1); // (1000 - 500) / 10 = 50
+      expect(shades![950].tone).toBeCloseTo(5, 1); // (1000 - 950) / 10 = 5
+    });
+  });
+});

--- a/packages/@poupe-tailwindcss/src/theme/index.ts
+++ b/packages/@poupe-tailwindcss/src/theme/index.ts
@@ -14,6 +14,7 @@ export {
 export {
   type Shades,
   defaultShades,
+  makeHexShades,
   makeShades,
   validShade,
 } from './shades';

--- a/packages/@poupe-tailwindcss/src/theme/index.ts
+++ b/packages/@poupe-tailwindcss/src/theme/index.ts
@@ -12,6 +12,13 @@ export {
 } from './plugin';
 
 export {
+  type Shades,
+  defaultShades,
+  makeShades,
+  validShade,
+} from './shades';
+
+export {
   makeTheme,
   makeThemeBases,
   makeThemeComponents,

--- a/packages/@poupe-tailwindcss/src/theme/shades.ts
+++ b/packages/@poupe-tailwindcss/src/theme/shades.ts
@@ -23,6 +23,7 @@ import {
   type Color,
   Hct,
   hct,
+  hexFromHct,
   splitHct,
 } from '@poupe/theme-builder/core';
 
@@ -135,4 +136,46 @@ export function makeShades<K extends number>(color: Color, shades: K[] | false):
 
 function toTone(shade: number): number {
   return Math.max(Math.min(1000 - shade, 1000), 0) / 10;
+}
+
+/**
+ * Generates a set of hex color values for each specified shade.
+ *
+ * This is a convenience wrapper around `makeShades()` that converts the Hct color objects
+ * to hexadecimal color strings for easier use in UI components and CSS.
+ *
+ * @param color - The base color to generate shades from
+ * @param shades - An array of shade values, or `false` to disable shade generation.
+ * Defaults to the standard shade scale (50-950)
+ *
+ * @returns A record mapping each shade value to its corresponding hex color string,
+ * or `undefined` if the provided shades are invalid or disabled
+ *
+ * @example
+ * ```
+ * // Generate standard hex shades
+ * const blueHexShades = makeHexShades('#0047AB');
+ * // Result: { 50: '#E6F0FF', 100: '#CCE0FF', ... 950: '#00142E' }
+ *
+ * // Generate custom hex shades
+ * const customShades = makeHexShades('#0047AB', [100, 500, 900]);
+ * // Result: { 100: '#CCE0FF', 500: '#0047AB', 900: '#00183D' }
+ *
+ * // Disable shades
+ * const noShades = makeHexShades('#0047AB', false);
+ * // Result: undefined
+ * ```
+ */
+export function makeHexShades(
+  color: Color,
+  shades: Shades = defaultShades,
+) {
+  const validShades = makeShades<number>(color, shades);
+  if (!validShades) {
+    return undefined;
+  }
+
+  return Object.fromEntries(Object.entries(validShades).map(([shade, hct]) => {
+    return [shade, hexFromHct(hct)];
+  }));
 }

--- a/packages/@poupe-tailwindcss/src/theme/shades.ts
+++ b/packages/@poupe-tailwindcss/src/theme/shades.ts
@@ -1,3 +1,24 @@
+/**
+ * This module provides utilities for generating, validating, and managing color shades
+ * in a design system. It converts colors to different shade variants based on the HCT
+ * (Hue, Chroma, Tone) color space, which provides perceptually consistent color gradations.
+ *
+ * Key features:
+ * - Defines standard shade scales (50-950)
+ * - Validates shade values for consistency
+ * - Converts between color formats and shade values
+ * - Supports custom shade definitions with flexible configuration
+ * - Generates color palettes based on a single color reference
+ *
+ * @example
+ * ```
+ * // Generate standard shades from a color
+ * const blueShades = makeHexShades('#0047AB');
+ *
+ * // Generate custom shades
+ * const customShades = makeHexShades('#0047AB', [100, 300, 500, 700, 900]);
+ * ```
+ */
 import {
   type Color,
   Hct,
@@ -70,6 +91,31 @@ export function validShade(n: number): boolean {
   return n > 0 && n < 1000 && Math.round(n) == n;
 }
 
+/**
+ * Generates a set of Hct color objects for each specified shade value.
+ *
+ * This function creates a palette of colors by varying the tone (lightness) while
+ * preserving the hue and chroma of the input color. It maps each shade value to a
+ * corresponding HCT color object.
+ *
+ * @param color - The base color to generate shades from
+ * @param shades - An array of shade values (numbers between 1-999) or `false` to disable shade generation
+ *
+ * @returns A record mapping each shade value to its corresponding Hct color object,
+ * or `undefined` if the provided shades are invalid or disabled
+ *
+ * @example
+ * ```
+ * // Generate standard shades from a color
+ * const blueHct = hct('#0047AB');
+ * const blueShades = makeShades(blueHct, [100, 300, 500, 700]);
+ * // Result: { 100: Hct, 300: Hct, 500: Hct, 700: Hct }
+ *
+ * // Disable shades
+ * const noShades = makeShades(blueHct, false);
+ * // Result: undefined
+ * ```
+ */
 export function makeShades(color: Color, shades: false): undefined;
 export function makeShades<K extends number>(color: Color, shades: K[]): Record<K, Hct>;
 export function makeShades<K extends number>(color: Color, shades: K[] | false): Record<K, Hct> | undefined;

--- a/packages/@poupe-tailwindcss/src/theme/types.ts
+++ b/packages/@poupe-tailwindcss/src/theme/types.ts
@@ -22,11 +22,6 @@ export {
   type StandardPaletteKey,
 } from '@poupe/theme-builder';
 
-export {
-  defaultShades,
-  type Shades,
-} from './shades';
-
 export type Theme = {
   readonly options: ThemeOptions
   readonly paletteKeys: string[]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a utility to generate color shades as hex strings for easier theme customization.

- **Documentation**
  - Significantly expanded and reorganized the README for improved clarity and usability, including detailed usage examples and an API reference.

- **Tests**
  - Introduced comprehensive tests for color shade utilities to ensure robust validation and color generation.

- **Chores**
  - Updated package version to 0.3.2.

- **Refactor**
  - Adjusted export statements for improved module clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->