### PR TITLE
feat(theme-builder): re-export formatCSSRules from @poupe/css

### DIFF
--- a/packages/@poupe-theme-builder/package.json
+++ b/packages/@poupe-theme-builder/package.json
@@ -69,7 +69,6 @@
     "@poupe/css": "workspace:^",
     "colord": "^2.9.3",
     "defu": "^6.1.4",
-    "tailwindcss": "^4.1.7",
     "type-fest": "^4.41.0"
   },
   "devDependencies": {

--- a/packages/@poupe-theme-builder/package.json
+++ b/packages/@poupe-theme-builder/package.json
@@ -1,25 +1,30 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "Design token management and theme generation system for Poupe UI framework",
   "author": "Alejandro Mery <amery@apptly.co>",
   "license": "MIT",
   "keywords": [
-    "design-tokens",
-    "theme",
     "color-system",
-    "material-design",
-    "poupe",
-    "ui-framework",
     "design-system",
-    "typescript"
-  ],
+    "design-tokens",
+    "material-design",
+    "material-design-3",
+    "poupe",
+    "theme",
+    "typescript",
+    "ui-framework"
+    ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/poupe-ui/poupe.git",
     "directory": "packages/@poupe-theme-builder"
   },
+  "bugs": {
+    "url": "https://github.com/poupe-ui/poupe/issues"
+  },
+  "homepage": "https://poupe.dev",
   "exports": {
     ".": {
       "import": {

--- a/packages/@poupe-theme-builder/src/core.ts
+++ b/packages/@poupe-theme-builder/src/core.ts
@@ -18,11 +18,16 @@ import {
 
 // re-export
 //
-export * from './core/colors';
-
 export {
   customColor as customColorFromArgb,
 } from '@material/material-color-utilities';
+
+export {
+  formatCSSRules,
+  formatCSSRulesArray,
+} from '@poupe/css';
+
+export * from './core/colors';
 
 // DynamicScheme
 //

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,9 +209,6 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.4
-      tailwindcss:
-        specifier: ^4.1.7
-        version: 4.1.7
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package metadata with new keywords, homepage, and bugs URL.
  - Removed the dependency on Tailwind CSS.

- **New Features**
  - Added new exports for CSS rule formatting utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->