### PR TITLE
feat(css): introduce getDeepRule() and simplify setDeepRule typing. improve README

### DIFF
--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -401,6 +401,36 @@ setDeepRule(existingRules, 'button', { color: 'blue', padding: '10px' });
 // Result: { button: { color: 'blue', margin: '5px', padding: '10px' } }
 ```
 
+#### `getDeepRule(target, path)`
+Retrieves a CSS rule value from a specified path within a target object.
+This function is overloaded to provide type safety for both general
+`CSSRules` objects and TailwindCSS-compatible `CSSRuleObject` types.
+
+```typescript
+import { getDeepRule } from '@poupe/css';
+
+const rules = {
+  components: { button: { color: 'blue' } },
+  utils: ['clearfix', 'sr-only']
+};
+
+// Direct access
+getDeepRule(rules, 'utils');
+// Result: ['clearfix', 'sr-only']
+
+// Nested access
+getDeepRule(rules, ['components', 'button', 'color']);
+// Result: 'blue'
+
+// Non-existent path
+getDeepRule(rules, ['components', 'header']);
+// Result: undefined
+
+// Root access (empty array)
+getDeepRule(rules, []);
+// Result: { components: { ... }, utils: [...] }
+```
+
 ### Utility Functions
 
 #### `unsafeKeys<T>(object: T): Array<keyof T>`

--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -376,6 +376,31 @@ const filteredRules = renameRules(rules, key =>
 // }
 ```
 
+#### `setDeepRule(target, path, object)`
+Sets a CSS rule object at a specified path within a target object,
+merging with existing objects and creating intermediate objects as needed.
+This function is overloaded to provide type safety for both general
+`CSSRules` objects and TailwindCSS-compatible `CSSRuleObject` types.
+
+```typescript
+import { setDeepRule } from '@poupe/css';
+
+const rules = {};
+
+// Direct assignment
+setDeepRule(rules, 'button', { color: 'blue' });
+// Result: { button: { color: 'blue' } }
+
+// Nested assignment
+setDeepRule(rules, ['components', 'button'], { color: 'blue' });
+// Result: { components: { button: { color: 'blue' } } }
+
+// Merging with existing object (new values take precedence)
+const existingRules = { button: { color: 'red', margin: '5px' } };
+setDeepRule(existingRules, 'button', { color: 'blue', padding: '10px' });
+// Result: { button: { color: 'blue', margin: '5px', padding: '10px' } }
+```
+
 ### Utility Functions
 
 #### `unsafeKeys<T>(object: T): Array<keyof T>`

--- a/packages/@poupe-css/README.md
+++ b/packages/@poupe-css/README.md
@@ -1,10 +1,11 @@
 # @poupe/css
 
-[![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@poupe/css)
-[![npm version](https://img.shields.io/npm/v/@poupe/css.svg)](https://www.npmjs.com/package/@poupe/css)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENCE.txt)
+[![jsDocs.io][jsdocs-badge]][jsdocs-url]
+[![npm version][npm-badge]][npm-url]
+[![License: MIT][license-badge]][license-url]
 
-A TypeScript utility library for CSS property manipulation, formatting, and CSS-in-JS operations.
+A TypeScript utility library for CSS property manipulation, formatting, and
+CSS-in-JS operations.
 
 ## Table of Contents
 
@@ -46,7 +47,8 @@ pnpm add -D @poupe/css
 
 The library exports several categories of utilities:
 
-- **Case Conversion**: Functions for converting between different CSS naming conventions
+- **Case Conversion**: Functions for converting between different CSS naming
+  conventions
 - **CSS Stringification**: Tools to convert CSS objects to strings
 - **CSS Variables**: Utilities for working with CSS custom properties
 - **CSS Rules**: Functions for handling nested CSS rule objects
@@ -78,7 +80,7 @@ type CSSPropertiesOptions = {
   newLine?: string
   /** Whether to format output on a single line, defaults to false. */
   inline?: boolean
-  /** Maximum number of properties to format on a single line, defaults to 1. */
+  /** Max properties to format on a single line, defaults to 1. */
   singleLineThreshold?: number
 }
 ```
@@ -92,7 +94,8 @@ type CSSRules = {
 ```
 
 #### `CSSRuleObject`
-A more restrictive subset of CSSRules that is compatible with TailwindCSS plugin API:
+A more restrictive subset of CSSRules that is compatible with TailwindCSS
+plugin API:
 ```typescript
 type CSSRuleObject = {
   [key: string]: string | string[] | CSSRuleObject
@@ -103,7 +106,7 @@ type CSSRuleObject = {
 Configuration options for formatting CSS rules:
 ```typescript
 interface CSSRulesFormatOptions {
-  /** Indentation string to use for each level of nesting, defaults to two spaces. */
+  /** Indentation string for each level of nesting, defaults to two spaces. */
   indent?: string
   /** Prefix string added before each line, defaults to empty string. */
   prefix?: string
@@ -114,10 +117,13 @@ interface CSSRulesFormatOptions {
 
 ### CSS Property Functions
 
-#### `stringifyCSSProperties<K extends string>(object: CSSProperties<K>, options?: CSSPropertiesOptions): string`
-Converts a CSSProperties object into a formatted CSS string representation with proper indentation.
-Property values are intelligently formatted based on their type and the CSS property name - space-delimited
-properties (like margin, padding) use spaces between multiple values, while other properties use commas.
+#### `stringifyCSSProperties<K extends string>`
+`(object: CSSProperties<K>, options?: CSSPropertiesOptions): string`
+Converts a CSSProperties object into a formatted CSS string representation
+with proper indentation. Property values are intelligently formatted based on
+their type and the CSS property name - space-delimited properties (like
+margin, padding) use spaces between multiple values, while other properties
+use commas.
 
 ```typescript
 import { stringifyCSSProperties } from '@poupe/css';
@@ -140,12 +146,14 @@ const cssString = stringifyCSSProperties(styles);
 
 // Inline formatting
 const inlineCSS = stringifyCSSProperties(styles, { inline: true });
-// "{ font-size: 16px; background-color: red; margin: 10 20px 30px 40px; font-family: Arial, sans-serif }"
+// "{ font-size: 16px; background-color: red; margin: 10 20px 30px 40px;
+//   font-family: Arial, sans-serif }"
 ```
 
 #### `formatCSSProperties<K extends string>(object: CSSProperties<K>): string[]`
-Formats a CSS properties object into an array of CSS property strings. Automatically handles deduplication of
-properties, where later declarations override earlier ones while preserving the original insertion order.
+Formats a CSS properties object into an array of CSS property strings.
+Automatically handles deduplication of properties, where later declarations
+override earlier ones while preserving the original insertion order.
 
 ```typescript
 import { formatCSSProperties } from '@poupe/css';
@@ -168,25 +176,29 @@ const cssLines = formatCSSProperties(styles);
 
 #### `formatCSSValue(value: CSSValue, useComma = true): string`
 Formats a CSS value into a string. If the value is an array:
-- By default, it joins the elements with commas (appropriate for properties like `font-family`)
-- When `useComma` is set to `false`, it uses spaces (appropriate for properties like `margin` or `padding`)
+- By default, it joins the elements with commas (appropriate for properties
+  like `font-family`)
+- When `useComma` is set to `false`, it uses spaces (appropriate for
+  properties like `margin` or `padding`)
 
-The function automatically handles quoting strings that contain spaces (except CSS functions like
-`rgb()` or `calc()`), enclosing them in double quotes.
+The function automatically handles quoting strings that contain spaces (except
+CSS functions like `rgb()` or `calc()`), enclosing them in double quotes.
 
 ```typescript
 import { formatCSSValue } from '@poupe/css';
 
 formatCSSValue('16px'); // "16px"
 formatCSSValue('Open Sans'); // "\"Open Sans\""
-formatCSSValue([10, '20px', '30px']); // "10, 20px, 30px" (comma-separated by default)
+formatCSSValue([10, '20px', '30px']); // "10, 20px, 30px" (comma-separated)
 formatCSSValue([10, '20px', '30px'], false); // "10 20px 30px" (space-separated)
-formatCSSValue('rgb(255, 0, 0)'); // "rgb(255, 0, 0)" - Not quoted despite spaces
-formatCSSValue('calc(100% - 20px)'); // "calc(100% - 20px)" - Not quoted despite spaces
+formatCSSValue('rgb(255, 0, 0)'); // "rgb(255, 0, 0)" - Not quoted despite
+formatCSSValue('calc(100% - 20px)'); // "calc(100% - 20px)" - Not quoted
 ```
 
-#### `properties<K extends string>(object: CSSProperties<K>): Generator<[K, CSSValue]>`
-Generates a sequence of valid CSS property key-value pairs from a CSSProperties object.
+#### `properties<K extends string>`
+`(object: CSSProperties<K>): Generator<[K, CSSValue]>`
+Generates a sequence of valid CSS property key-value pairs from a
+CSSProperties object.
 Filters out invalid or empty CSS property values.
 
 ```typescript
@@ -211,7 +223,8 @@ for (const [key, value] of properties(styles)) {
 ### CSS Rules Functions
 
 #### `stringifyCSSRules(rules: CSSRules | CSSRuleObject, options?): string`
-Converts a CSS rule object into a formatted string representation with proper indentation and nesting.
+Converts a CSS rule object into a formatted string representation with proper
+indentation and nesting.
 
 ```typescript
 import { stringifyCSSRules } from '@poupe/css';
@@ -246,7 +259,8 @@ const cssString = stringifyCSSRules(rules);
 ```
 
 #### `formatCSSRules(rules: CSSRules | CSSRuleObject, options?): string[]`
-Processes a CSS rule object and returns an array of strings, where each string represents a line in the formatted CSS output.
+Processes a CSS rule object and returns an array of strings, where each
+string represents a line in the formatted CSS output.
 
 ```typescript
 import { formatCSSRules } from '@poupe/css';
@@ -266,7 +280,8 @@ const indentedLines = formatCSSRules(rules, { indent: '    ' });
 // Returns: ['body {', '    color: red;', '    font-size: 16px;', '}']
 ```
 
-#### `formatCSSRulesArray(rules: (string | CSSRules | CSSRuleObject)[], options?): string[]`
+#### `formatCSSRulesArray`
+`(rules: (string | CSSRules | CSSRuleObject)[], options?): string[]`
 Formats an array of CSS rules into indented lines recursively.
 
 ```typescript
@@ -288,8 +303,9 @@ const lines = formatCSSRulesArray(rulesArray);
 ```
 
 #### `defaultValidCSSRule(key: string, value: CSSRulesValue): boolean`
-Default validation function that determines if a CSS rule key-value pair should be included in the output.
-A rule is considered valid if the key is not empty and the value is neither undefined nor null.
+Default validation function that determines if a CSS rule key-value pair
+should be included in the output. A rule is considered valid if the key is
+not empty and the value is neither undefined nor null.
 
 ```typescript
 import { defaultValidCSSRule } from '@poupe/css';
@@ -301,7 +317,8 @@ const customValid = (key, value) => {
 ```
 
 #### `interleavedRules(rules: CSSRules[]): CSSRules[]`
-Interleaves an array of CSS rule objects with empty objects, useful for creating spacing between rule blocks in the output.
+Interleaves an array of CSS rule objects with empty objects, useful for
+creating spacing between rule blocks in the output.
 
 ```typescript
 import { interleavedRules } from '@poupe/css';
@@ -323,7 +340,8 @@ const spacedRules = interleavedRules(rules);
 ```
 
 #### `renameRules(rules: CSSRules, fn: (name: string) => string): CSSRules`
-Renames the keys in a CSS rules object using the provided function, allowing for advanced selector manipulation.
+Renames the keys in a CSS rules object using the provided function, allowing
+for advanced selector manipulation.
 
 ```typescript
 import { renameRules } from '@poupe/css';
@@ -350,7 +368,8 @@ const utilityRules = renameRules(rules, key => `@utility ${key.slice(1)}`);
 // }
 
 // Return falsy from the function to skip/remove a rule
-const filteredRules = renameRules(rules, key => key.includes('button') ? key : null);
+const filteredRules = renameRules(rules, key =>
+  key.includes('button') ? key : null);
 // Returns:
 // {
 //   '.button': { color: 'blue' }
@@ -362,8 +381,10 @@ const filteredRules = renameRules(rules, key => key.includes('button') ? key : n
 #### `unsafeKeys<T>(object: T): Array<keyof T>`
 A type-safe wrapper around Object.keys that preserves the object's key types.
 
-#### `keys<T, K extends keyof T>(object: T, valid?: (key: keyof T) => boolean): Generator<K>`
-A generator function that yields keys of an object that pass an optional validation function.
+#### `keys<T, K extends keyof T>`
+`(object: T, valid?: (key: keyof T) => boolean): Generator<K>`
+A generator function that yields keys of an object that pass an optional
+validation function.
 
 ```typescript
 import { keys } from '@poupe/css';
@@ -381,22 +402,25 @@ for (const key of keys(obj, k => !k.startsWith('_'))) {
 }
 ```
 
-#### `pairs<K extends string, T>(object: Record<K, T>, valid?: (k: K, v: T) => boolean): Generator<[K, T]>`
-A generator function that yields valid key-value pairs from an object. Allows providing a custom validation function
-to determine which pairs to include.
+#### `pairs<K extends string, T>`
+`(object: Record<K, T>, valid?: (k: K, v: T) => boolean): Generator<[K, T]>`
+A generator function that yields valid key-value pairs from an object. Allows
+providing a custom validation function to determine which pairs to include.
 
 ```typescript
 import { pairs } from '@poupe/css';
 
 const obj = { color: 'red', fontSize: '16px', _private: 'hidden', empty: '' };
 
-// Use with default validation (excludes keys starting with underscore and null/empty values)
+// Use with default validation (excludes keys starting with underscore and
+// null/empty values)
 for (const [key, value] of pairs(obj)) {
   console.log(`${key}: ${value}`); // "color: red", "fontSize: 16px"
 }
 
 // Use with custom validation
-const customValid = (key: string, value: unknown) => typeof value === 'string' && value.length > 3;
+const customValid = (key: string, value: unknown) =>
+  typeof value === 'string' && value.length > 3;
 for (const [key, value] of pairs(obj, customValid)) {
   console.log(`${key}: ${value}`); // "color: red", "_private: hidden"
 }
@@ -478,3 +502,11 @@ const cssProperties = Object.entries(styleObject).map(
 ## License
 
 MIT licensed.
+
+<!-- Badge references -->
+[jsdocs-badge]: https://img.shields.io/badge/jsDocs.io-reference-blue
+[jsdocs-url]: https://www.jsdocs.io/package/@poupe/css
+[npm-badge]: https://img.shields.io/npm/v/@poupe/css.svg
+[npm-url]: https://www.npmjs.com/package/@poupe/css
+[license-badge]: https://img.shields.io/badge/License-MIT-blue.svg
+[license-url]: ../../LICENCE.txt

--- a/packages/@poupe-css/package.json
+++ b/packages/@poupe-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/css",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "description": "A TypeScript utility library for CSS property manipulation, formatting, and CSS-in-JS operations",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-css/src/index.ts
+++ b/packages/@poupe-css/src/index.ts
@@ -19,6 +19,7 @@ export {
   formatCSSRulesArray,
   interleavedRules,
   renameRules,
+  getDeepRule,
   setDeepRule,
   stringifyCSSRules,
 } from './rules';

--- a/packages/@poupe-css/src/rules.test.ts
+++ b/packages/@poupe-css/src/rules.test.ts
@@ -815,15 +815,15 @@ describe('setDeepRule', () => {
   });
 
   it('new values take precedence over existing values', () => {
-    const target = { button: { color: 'red', fontSize: '14px' } };
+    const target: CSSRules = { button: { color: 'red', fontSize: '14px' } };
 
     const result = setDeepRule(target, 'button', {
       color: 'blue',
       fontSize: '16px',
     });
 
-    expect(result.button.color).toBe('blue');
-    expect(result.button.fontSize).toBe('16px');
+    expect((result.button as CSSRules).color).toBe('blue');
+    expect((result.button as CSSRules).fontSize).toBe('16px');
   });
 
   it('preserves existing values not present in new object', () => {
@@ -855,8 +855,7 @@ describe('setDeepRule', () => {
   });
 
   it('works with complex CSS rule objects', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const target = {} as any;
+    const target: CSSRules = {};
     const cssRule = {
       'color': 'blue',
       'fontSize': '16px',
@@ -870,11 +869,12 @@ describe('setDeepRule', () => {
 
     const result = setDeepRule(target, ['theme', 'components', 'button'], cssRule);
 
-    expect(result.theme.components.button).toEqual(cssRule);
+    expect((result.theme as CSSRules).components).toBeDefined();
+    expect(((result.theme as CSSRules).components as CSSRules).button).toEqual(cssRule);
   });
 
   it('works with numeric indices in path array', () => {
-    const target = {
+    const target: CSSRules = {
       variants: [
         { name: 'primary' },
         { name: 'secondary' },
@@ -899,5 +899,38 @@ describe('setDeepRule', () => {
         },
       ],
     });
+  });
+
+  it('works with CSSRuleObject type for TailwindCSS compatibility', () => {
+    const target: CSSRuleObject = {};
+    const cssRule: CSSRuleObject = {
+      'color': 'blue',
+      'fontSize': '16px',
+      '@media (max-width: 768px)': {
+        fontSize: '14px',
+      },
+    };
+
+    const result = setDeepRule(target, 'button', cssRule);
+
+    expect(result).toEqual({
+      button: cssRule,
+    });
+    // Type check: result should be CSSRuleObject
+    expect(typeof result).toBe('object');
+  });
+
+  it('preserves type safety with overloaded signatures', () => {
+    // Test CSSRules type
+    const cssRulesTarget: CSSRules = {};
+    const cssRulesObject: CSSRules = { color: 'blue', nested: undefined };
+    const cssRulesResult = setDeepRule(cssRulesTarget, 'test', cssRulesObject);
+    expect(cssRulesResult).toBe(cssRulesTarget);
+
+    // Test CSSRuleObject type
+    const cssRuleTarget: CSSRuleObject = {};
+    const cssRuleObject: CSSRuleObject = { color: 'red' };
+    const cssRuleResult = setDeepRule(cssRuleTarget, 'test', cssRuleObject);
+    expect(cssRuleResult).toBe(cssRuleTarget);
   });
 });

--- a/packages/@poupe-css/src/rules.ts
+++ b/packages/@poupe-css/src/rules.ts
@@ -45,23 +45,23 @@ export type CSSRulesValue = CSSRules[string];
  */
 export interface CSSRulesFormatOptions {
   /**
-     * Indentation string to use for each level of nesting.
-     * @defaultValue `'  '` (two spaces)
-     */
+       * Indentation string to use for each level of nesting.
+       * @defaultValue `'  '` (two spaces)
+       */
   indent?: string
 
   /**
-     * Prefix string added before each line.
-     * @defaultValue `''` (empty string)
-     */
+       * Prefix string added before each line.
+       * @defaultValue `''` (empty string)
+       */
   prefix?: string
 
   /**
-     * Optional validation function to determine which rules to include.
-     * @param key - The rule name/selector
-     * @param value - The rule value
-     * @returns `true` if the rule should be included, `false` otherwise
-     */
+       * Optional validation function to determine which rules to include.
+       * @param key - The rule name/selector
+       * @param value - The rule value
+       * @returns `true` if the rule should be included, `false` otherwise
+       */
   valid?: (key: string, value: CSSRulesValue) => boolean
 }
 
@@ -109,9 +109,9 @@ export function stringifyCSSRules(
   rules: CSSRules | CSSRuleObject = {},
   options: CSSRulesFormatOptions & {
     /**
-         * Character(s) to use for line breaks.
-         * @defaultValue `'\n'`
-         */
+             * Character(s) to use for line breaks.
+             * @defaultValue `'\n'`
+             */
     newLine?: string
   } = {}): string {
   const {
@@ -418,4 +418,66 @@ export function setDeepRule(target: CSSRules, path: string | string[], object: C
   p[lastKey] = defu(object, p[lastKey] ?? {} as typeof object);
 
   return target;
+}
+
+/**
+ * Retrieves a CSS rule value from a specified path within a target object.
+ *
+ * This function allows for deep retrieval of CSS rules from a nested object
+ * structure. It can handle both string paths for top-level access and array
+ * paths for nested access.
+ *
+ * The function is overloaded to provide type safety for both general
+ * `CSSRules` objects and TailwindCSS-compatible `CSSRuleObject` types.
+ *
+ * @param target - The target CSS rules object to search within
+ * @param path - Either a string key for direct access or an array of
+ *   string keys for nested access
+ * @returns The value at the specified path, or `undefined` if the path
+ *   does not exist
+ *
+ * @example
+ * ```
+ * const rules = {
+ *   components: { button: { color: 'blue' } },
+ *   utils: ['clearfix', 'sr-only']
+ * };
+ *
+ * // Direct access
+ * getDeepRule(rules, 'utils');
+ * // Result: ['clearfix', 'sr-only']
+ *
+ * // Nested access
+ * getDeepRule(rules, ['components', 'button', 'color']);
+ * // Result: 'blue'
+ *
+ * // Non-existent path
+ * getDeepRule(rules, ['components', 'header']);
+ * // Result: undefined
+ *
+ * // Root access (empty array)
+ * getDeepRule(rules, []);
+ * // Result: { components: { ... }, utils: [...] }
+ * ```
+ */
+export function getDeepRule(target: CSSRuleObject, path: string | string[]): CSSRuleObject | undefined;
+export function getDeepRule(target: CSSRules, path: string | string[]): CSSRulesValue | undefined;
+export function getDeepRule(target: CSSRules, path: string | string[]): CSSRulesValue | undefined {
+  const segments = typeof path === 'string' ? [path] : path;
+
+  if (segments.length === 0) {
+    // Empty path returns the target object itself
+    return target;
+  }
+
+  let current: CSSRulesValue = target;
+  for (const key of segments) {
+    if (typeof current !== 'object' || current === null
+      || !Object.prototype.hasOwnProperty.call(current, key)) {
+      return undefined;
+    }
+    current = (current as CSSRules)[key];
+  }
+
+  return current;
 }

--- a/packages/@poupe-css/src/rules.ts
+++ b/packages/@poupe-css/src/rules.ts
@@ -352,13 +352,6 @@ export function renameRules(rules: CSSRules, fn: (name: string) => string): CSSR
 }
 
 /**
- * Represents a deeply nested object structure with arbitrary nesting levels.
- */
-type RecursiveObject<T = unknown> = {
-  [key: string]: RecursiveObject<T> | T
-};
-
-/**
  * Sets a CSS rule object at a specified path within a target object,
  * merging with existing objects and creating intermediate objects as needed.
  *
@@ -368,11 +361,14 @@ type RecursiveObject<T = unknown> = {
  * an object, the new object is merged with the existing one, with new values
  * taking precedence.
  *
- * @param target - The target object to modify
+ * The function is overloaded to provide type safety for both general
+ * `CSSRules` objects and TailwindCSS-compatible `CSSRuleObject` types.
+ *
+ * @param target - The target CSS rules object to modify
  * @param path - Either a string key for direct assignment or an array of
  *   string keys for nested assignment
  * @param object - The CSS rule object to set at the specified path
- * @returns The modified target object
+ * @returns The modified target object (same type as input)
  * @remarks The target object is modified in place, returned reference is
  *   only a convenience.
  *
@@ -392,8 +388,10 @@ type RecursiveObject<T = unknown> = {
  * // Result: { button: { color: 'blue', margin: '5px', padding: '10px' } }
  * ```
  */
-export function setDeepRule<T extends RecursiveObject>(target: T, path: string | string[], object: CSSRuleObject): T {
-  let p: RecursiveObject = target;
+export function setDeepRule(target: CSSRuleObject, path: string | string[], object: CSSRuleObject): CSSRuleObject;
+export function setDeepRule(target: CSSRules, path: string | string[], object: CSSRules): CSSRules;
+export function setDeepRule(target: CSSRules, path: string | string[], object: CSSRules): CSSRules {
+  let p: CSSRules = target;
   let lastKey = '';
 
   if (Array.isArray(path)) {
@@ -403,12 +401,12 @@ export function setDeepRule<T extends RecursiveObject>(target: T, path: string |
     for (let i = 0; i < path.length - 1; i++) {
       const k = path[i];
       if (p[k] === undefined) {
-        p[k] = {} as RecursiveObject<T>;
+        p[k] = {} as CSSRules;
       } else if (typeof p[k] !== 'object' || p[k] === null) {
         throw new Error(`Invalid path at segment ${i}: "${k}" in path: ${path.join('.')}: ${typeof p[k]}`);
       }
 
-      p = p[k] as RecursiveObject<T>;
+      p = p[k] as CSSRules;
     }
 
     // Assign the obj to the last path segment


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced utility functions for safely setting and retrieving nested CSS rule objects, including support for complex nested structures.

- **Documentation**
  - Expanded and clarified documentation with improved formatting, additional examples, and clearer explanations for new and existing utility functions.

- **Tests**
  - Added comprehensive tests for the new and updated utility functions, ensuring type safety and correct behavior for various nested scenarios.

- **Chores**
  - Updated package version to 0.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->