### PR TITLE
feat: refactor selector handling in `@poupe/theme-builder` and `@poupe/tailwindcss`

### DIFF
--- a/packages/@poupe-tailwindcss/package.json
+++ b/packages/@poupe-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/tailwindcss",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "type": "module",
   "description": "TailwindCSS v4 plugin for Poupe UI framework with theme customization support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-tailwindcss/src/theme/theme.ts
+++ b/packages/@poupe-tailwindcss/src/theme/theme.ts
@@ -307,6 +307,7 @@ export function makeThemeBases(
         darkSuffix: theme.options.darkSuffix,
         lightSuffix: theme.options.lightSuffix,
         stringify: stringify || hslString,
+        addStarVariantsToDark: false,
       },
     );
 

--- a/packages/@poupe-tailwindcss/src/theme/variants.ts
+++ b/packages/@poupe-tailwindcss/src/theme/variants.ts
@@ -1,4 +1,5 @@
 import {
+  processCSSSelectors,
   type CSSRuleObject,
 } from '@poupe/css';
 
@@ -94,11 +95,8 @@ export function getDarkMode(darkMode: DarkModeStrategy = 'class'): string[] {
         const [mode, value] = darkMode;
         switch (mode) {
           case 'class':
-          case 'selector': {
-            const v = makeDarkModeSelector(value);
-            if (v.length > 0)
-              return v;
-          }
+          case 'selector':
+            return processCSSSelectors(value) ?? [defaultDarkSelector];
         }
 
         // TODO: variant modes
@@ -107,23 +105,6 @@ export function getDarkMode(darkMode: DarkModeStrategy = 'class'): string[] {
       throw new Error(`Invalid darkMode strategy: ${JSON.stringify(darkMode)}.`);
     }
   }
-}
-
-function makeDarkModeSelector(value: string | string[]): string[] {
-  if (Array.isArray(value)) {
-    const sanitized: string[] = [];
-
-    // remove empty slots
-    for (const v of value) {
-      const trimmed = v.trim();
-      if (trimmed != '') sanitized.push(trimmed);
-    }
-
-    return sanitized.length > 0 ? sanitized : [defaultDarkSelector];
-  }
-
-  const trimmed = value.trim();
-  return trimmed == '' ? [defaultDarkSelector] : [trimmed];
 }
 
 const defaultDarkSelector = '.dark, .dark *';

--- a/packages/@poupe-theme-builder/README.md
+++ b/packages/@poupe-theme-builder/README.md
@@ -85,7 +85,20 @@ const cssTheme = makeCSSTheme({
   scheme: 'content',
   contrastLevel: 0.5,
   prefix: 'md-',
-  darkMode: '.dark',
+  darkMode: ['.dark', 'media'],    // Multiple selectors with aliases
+  lightMode: '.light',
+})
+
+// Built-in responsive aliases
+makeCSSTheme(colors, { 
+  darkMode: ['dark', 'mobile'],    // Uses media queries
+  lightMode: ['light', 'desktop']  // Now supports arrays too
+})
+
+// Advanced selector configuration
+const advancedTheme = makeCSSTheme(colors, {
+  darkMode: ['mobile', '.dark-mode'],   // Mobile screens + custom class
+  lightMode: ['desktop', '.light-mode'], // Desktop + custom class
 })
 
 // Use generated CSS variables
@@ -254,14 +267,23 @@ cssTheme.styles                   // CSS rule objects
 
 ## Dark Mode
 
-Built-in dark mode support with flexible selectors:
+Built-in dark mode support with flexible selectors and aliases:
 
 ```typescript
 // Class-based dark mode (default)
 makeCSSTheme(colors, { darkMode: '.dark' })
 
-// Media query dark mode
+// Media query dark mode using built-in alias
 makeCSSTheme(colors, { darkMode: 'media' })
+
+// Multiple selectors
+makeCSSTheme(colors, { darkMode: ['.dark', '.theme-dark'] })
+
+// Built-in responsive aliases
+makeCSSTheme(colors, { 
+  darkMode: ['dark', 'mobile'],  // Uses media queries
+  lightMode: 'light'
+})
 
 // Custom selectors
 makeCSSTheme(colors, {
@@ -271,6 +293,24 @@ makeCSSTheme(colors, {
 
 // Disable dark mode
 makeCSSTheme(colors, { darkMode: false })
+```
+
+### Built-in Selector Aliases
+
+The theme builder includes convenient aliases for common media queries:
+
+- `'media'` or `'dark'` → `'@media (prefers-color-scheme: dark)'`
+- `'light'` → `'@media (prefers-color-scheme: light)'`
+- `'mobile'` → `'@media (max-width: 768px)'`
+- `'tablet'` → `'@media (min-width: 769px) and (max-width: 1024px)'`
+- `'desktop'` → `'@media (min-width: 1025px)'`
+
+```typescript
+// Using aliases for responsive theming
+const cssTheme = makeCSSTheme(colors, {
+  darkMode: ['dark', 'tablet'],     // Dark mode + tablet screens
+  lightMode: ['light', 'desktop'],  // Light mode + desktop screens
+})
 ```
 
 ## Integration with Poupe Ecosystem

--- a/packages/@poupe-theme-builder/package.json
+++ b/packages/@poupe-theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "description": "Design token management and theme generation system for Poupe UI framework",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-theme-builder/src/css/__tests__/css.test.ts
+++ b/packages/@poupe-theme-builder/src/css/__tests__/css.test.ts
@@ -60,27 +60,27 @@ describe('defaultCSSThemeOptions', () => {
 
 describe('defaultDarkSelector', () => {
   it('should return .dark for true or .dark', () => {
-    expect(defaultDarkSelector({ darkMode: true })).toBe('.dark, .dark *');
-    expect(defaultDarkSelector({ darkMode: '.dark' })).toBe('.dark, .dark *');
+    expect(defaultDarkSelector({ darkMode: true })).toEqual(['.dark, .dark *']);
+    expect(defaultDarkSelector({ darkMode: '.dark' })).toEqual(['.dark, .dark *']);
   });
 
   it('should return media query for false, empty string, or media', () => {
-    const mediaQuery = '@media not print and (prefers-color-scheme: dark)';
-    expect(defaultDarkSelector({ darkMode: false })).toBe(mediaQuery);
-    expect(defaultDarkSelector({ darkMode: '' })).toBe(mediaQuery);
-    expect(defaultDarkSelector({ darkMode: 'media' })).toBe(mediaQuery);
+    const mediaQuery = '@media (prefers-color-scheme: dark)';
+    expect(defaultDarkSelector({ darkMode: false })).toEqual([mediaQuery]);
+    expect(defaultDarkSelector({ darkMode: '' })).toEqual([mediaQuery]);
+    expect(defaultDarkSelector({ darkMode: 'media' })).toEqual([mediaQuery]);
   });
 
   it('should return custom selector when provided', () => {
     const custom = '.custom-dark-mode';
-    expect(defaultDarkSelector({ darkMode: custom })).toBe(`${custom}, ${custom} *`);
+    expect(defaultDarkSelector({ darkMode: custom })).toEqual([`${custom}, ${custom} *`]);
   });
 });
 
 describe('defaultLightSelector', () => {
   it('should return .light for true or .light', () => {
-    expect(defaultLightSelector({ lightMode: true })).toBe('.light, .light *');
-    expect(defaultLightSelector({ lightMode: '.light' })).toBe('.light, .light *');
+    expect(defaultLightSelector({ lightMode: true })).toEqual(['.light, .light *']);
+    expect(defaultLightSelector({ lightMode: '.light' })).toEqual(['.light, .light *']);
   });
 
   it('should return undefined for false or empty string', () => {
@@ -90,7 +90,7 @@ describe('defaultLightSelector', () => {
 
   it('should return custom selector when provided', () => {
     const custom = '.custom-light-mode';
-    expect(defaultLightSelector({ lightMode: custom })).toBe(`${custom}, ${custom} *`);
+    expect(defaultLightSelector({ lightMode: custom })).toEqual([`${custom}, ${custom} *`]);
   });
 });
 
@@ -416,20 +416,18 @@ describe('deduplication in generateCSSColorVariables', () => {
 });
 
 describe('defaultRootLightSelector', () => {
-  if (typeof defaultRootLightSelector === 'function') {
-    it('should return :root when lightMode is false or empty', () => {
-      expect(defaultRootLightSelector({ lightMode: false })).toBe(':root');
-      expect(defaultRootLightSelector({ lightMode: '' })).toBe(':root');
-    });
+  it('should return :root when lightMode is false or empty', () => {
+    expect(defaultRootLightSelector({ lightMode: false })).toEqual([':root']);
+    expect(defaultRootLightSelector({ lightMode: '' })).toEqual([':root']);
+  });
 
-    it('should combine :root with light selector when lightMode is defined', () => {
-      const selector = defaultRootLightSelector({ lightMode: '.light-theme' });
-      expect(selector).toBe(':root, .light-theme, .light-theme *');
+  it('should combine :root with light selector when lightMode is defined', () => {
+    const selector = defaultRootLightSelector({ lightMode: '.light-theme' });
+    expect(selector).toEqual([':root, .light-theme, .light-theme *']);
 
-      const defaultSelector = defaultRootLightSelector({});
-      expect(defaultSelector).toBe(':root, .light, .light *');
-    });
-  }
+    const defaultSelector = defaultRootLightSelector({});
+    expect(defaultSelector).toEqual([':root, .light, .light *']);
+  });
 });
 
 describe('assembleCSSRules', () => {
@@ -448,6 +446,7 @@ describe('assembleCSSRules', () => {
       expect(result[0][':root']).toEqual(root);
       expect(result[1]).toHaveProperty(':root, .light, .light *');
       expect(result[1][':root, .light, .light *']).toEqual(light);
+      expect(result[1]).toHaveProperty('.dark, .dark *');
       expect(result[1]['.dark, .dark *']).toEqual(dark);
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced theme builder now supports multiple selectors and built-in aliases for dark and light mode, enabling more flexible and responsive theming configurations.
  - Introduced options to control star selector variants for dark and light modes.

- **Documentation**
  - Updated documentation with detailed examples and explanations for advanced dark and light mode selector configurations, including usage of media queries and responsive breakpoints.

- **Bug Fixes**
  - Corrected test assertions and improved test coverage for selector handling in dark and light modes.

- **Chores**
  - Updated package versions for theme builder and Tailwind CSS integration packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->