### PR TITLE
feat(vue): update shadow variant levels and fix surface options for cards.

### DIFF
--- a/packages/@poupe-nuxt/package.json
+++ b/packages/@poupe-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/nuxt",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "type": "module",
   "description": "Nuxt module for integrating Poupe UI framework with theme customization and components",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-nuxt/playground/app.vue
+++ b/packages/@poupe-nuxt/playground/app.vue
@@ -1,15 +1,5 @@
-<template>
-  <div class="container h-screen mx-auto">
-    Nuxt module playground!
-    <Placeholder
-      class="opacity-30 m-2 md:mx-0"
-      border="solid"
-    />
-  </div>
-</template>
-
 <script setup lang="ts">
-import { Placeholder } from '@poupe/vue';
+import { useHead } from '#imports';
 
 useHead({
   bodyAttrs: {
@@ -17,3 +7,18 @@ useHead({
   },
 });
 </script>
+
+<template>
+  <div class="flex flex-1 h-screen justify-center items-center">
+    <div class="container">
+      <p-card
+        class="m-auto w-full max-w-2xl"
+        title="@poupe/vue"
+        shadow="z2"
+        surface="high"
+      >
+        <p-theme-scheme class="pb-2" />
+      </p-card>
+    </div>
+  </div>
+</template>

--- a/packages/@poupe-vue/package.json
+++ b/packages/@poupe-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/vue",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "type": "module",
   "description": "Vue component library for Poupe UI framework with theme customization and accessibility support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-vue/src/app.vue
+++ b/packages/@poupe-vue/src/app.vue
@@ -15,11 +15,13 @@ useHead({
 </script>
 
 <template>
-  <div class="flex flex-1 h-screen justify-center">
-    <div class="flex container justify-center">
+  <div class="flex flex-1 h-screen justify-center items-center">
+    <div class="container">
       <card
         class="m-auto w-full max-w-2xl"
         title="@poupe/vue"
+        shadow="z2"
+        surface="high"
       >
         <theme-scheme class="pb-2" />
       </card>

--- a/packages/@poupe-vue/src/components/__tests__/button.spec.ts
+++ b/packages/@poupe-vue/src/components/__tests__/button.spec.ts
@@ -70,9 +70,9 @@ describe('Button', () => {
 
   it('should apply shadow variants correctly', () => {
     const wrapper = mount(Button, {
-      props: { shadow: 'lg' },
+      props: { shadow: 'z3' },
     });
-    expect(wrapper.classes()).toContain('shadow-lg');
+    expect(wrapper.classes()).toContain('shadow-z3');
   });
 
   it('should apply surface variants correctly', () => {
@@ -102,7 +102,7 @@ describe('Button', () => {
       size: 'lg',
       border: 'primary',
       rounded: 'lg',
-      shadow: 'lg',
+      shadow: 'z1',
       surface: 'primary',
       expand: true,
     };
@@ -111,7 +111,7 @@ describe('Button', () => {
     expect(wrapper.classes()).toContain('text-base'); // lg size class
     expect(wrapper.classes()).toContain('border-primary');
     expect(wrapper.classes()).toContain('rounded-lg');
-    expect(wrapper.classes()).toContain('shadow-lg');
+    expect(wrapper.classes()).toContain('shadow-z1');
     expect(wrapper.classes()).toContain('bg-primary');
     expect(wrapper.classes()).toContain('w-full');
   });

--- a/packages/@poupe-vue/src/components/card.vue
+++ b/packages/@poupe-vue/src/components/card.vue
@@ -41,7 +41,7 @@ const props = withDefaults(defineProps<CardProps>(), {
   title: undefined,
   rounded: 'xl' as const,
   shadow: 'none' as const,
-  surface: 'base' as const,
+  surface: 'high' as const,
 });
 
 const variants = computed(() => card({

--- a/packages/@poupe-vue/src/components/card.vue
+++ b/packages/@poupe-vue/src/components/card.vue
@@ -4,8 +4,8 @@ import {
   tv,
 
   onSlot,
+  containerVariants,
   roundedVariants,
-  surfaceVariants,
   shadowVariants,
 } from './variants';
 
@@ -16,7 +16,7 @@ const card = tv({
   variants: {
     rounded: onSlot('wrapper', roundedVariants),
     shadow: onSlot('wrapper', shadowVariants),
-    surface: onSlot('wrapper', surfaceVariants),
+    surface: onSlot('wrapper', containerVariants),
   },
 });
 

--- a/packages/@poupe-vue/src/components/variants/index.ts
+++ b/packages/@poupe-vue/src/components/variants/index.ts
@@ -42,18 +42,16 @@ export const roundedVariants = {
   ['3xl']: 'rounded-3xl',
 };
 
-// TODO: turn into elevation values
 export const shadowVariants = {
   current: 'shadow-shadow shadow',
   none: 'shadow-none',
 
-  xs: 'shadow-shadow shadow-sm',
-  sm: 'shadow-shadow shadow',
-  md: 'shadow-shadow shadow-md',
-  lg: 'shadow-shadow shadow-lg',
-  xl: 'shadow-shadow shadow-xl',
-  ['2xl']: 'shadow-shadow shadow-2xl',
-  inner: 'shadow-shadow shadow-inner',
+  z1: 'shadow-shadow shadow-z1',
+  z2: 'shadow-shadow shadow-z2',
+  z3: 'shadow-shadow shadow-z3',
+  z4: 'shadow-shadow shadow-z4',
+  z5: 'shadow-shadow shadow-z5',
+  inset: 'inset-shadow-shadow inset-shadow',
 };
 
 export const colorSurfaceVariants = {


### PR DESCRIPTION
also improve playgrounds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced visual styling for card components with new shadow and surface options, providing improved elevation and appearance.

- **Style**
  - Updated default layouts in example apps to use centered card designs with elevated shadows.
  - Card components now support higher elevation and surface styling.
  - Shadow variants updated to use elevation-based naming (z1–z5) instead of size-based classes.

- **Bug Fixes**
  - Adjusted button component tests and shadow variant options to use new elevation-based shadow classes for consistency.

- **Chores**
  - Incremented package versions for @poupe/nuxt and @poupe-vue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->