### PR TITLE
chore(deps): add dependencies label to renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "groupName": "Nuxt.js",


### PR DESCRIPTION
## Summary
- Added `dependencies` label to renovate.json configuration
- This ensures all Renovate PRs are automatically labeled for better organization

## Test plan
- [x] Updated renovate.json with new label configuration
- [ ] Verify next Renovate PR includes the dependencies label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a "dependencies" label to all Renovate pull requests and issues for improved categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->