### PR TITLE
release(@poupe/theme-builder): v0.10.4 + docs refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,8 +176,9 @@ Before committing any changes, ALWAYS run:
 
 The `pnpm precommit` command runs, in order:
 
-- Stub all packages (`dev:prepare` runs `unbuild --stub` so cross-package
-  type and lint resolution works)
+- Stub all packages (`dev:prepare` runs `obuild --stub` for the library
+  packages and `nuxt-module-build --stub` for `@poupe/nuxt` so
+  cross-package type and lint resolution works)
 - Run ESLint with auto-fix
 - Check TypeScript types
 - Build all packages (real build, prerequisite for tests)
@@ -368,15 +369,14 @@ When referencing other packages in the monorepo:
 
 ## Build Systems
 
-- **unbuild**: Used by @poupe/css, @poupe/theme-builder,
-  @poupe/tailwindcss, @poupe/nuxt
-- **obuild**: Used by @poupe/rolldown-vue-css
-- **vite**: Used by @poupe/vue for better Vue component handling
+- **obuild**: Used by @poupe/css, @poupe/theme-builder,
+  @poupe/tailwindcss, @poupe/vue, @poupe/rolldown-vue-css
+- **nuxt-module-build**: Used by @poupe/nuxt
 
 ## Common Dependencies
 
-- **TypeScript**: ~6.0.3 (strict mode enabled)
-- **Vitest**: ^3.2.4 for testing
+- **TypeScript**: ^6.0.3 (strict mode enabled)
+- **Vitest**: ^4.1.7 for testing
 - **ESLint**: Via @poupe/eslint-config
 - **Node.js**: >=20.19.2
 - **pnpm**: >=10.33.0
@@ -423,7 +423,8 @@ Each package has its own AGENTS.md file with specific details:
 
 ### Claude Code Specific Instructions
 
-- Use TodoWrite tool for complex multi-step tasks
+- Use the `TaskCreate` / `TaskUpdate` / `TaskList` tools for complex
+  multi-step work
 - **CRITICAL: Always enumerate files explicitly in git commit commands**
 - **NEVER use bare `git commit` without file arguments**
 - **Check `git status --porcelain` before every commit**

--- a/packages/@poupe-css/AGENTS.md
+++ b/packages/@poupe-css/AGENTS.md
@@ -86,8 +86,7 @@ This package is used by:
 
 ## Build Output
 
-Builds to both ESM and CJS formats:
+ESM-only via obuild:
 
-- `dist/index.mjs` - ES modules
-- `dist/index.cjs` - CommonJS
-- `dist/index.d.ts` - TypeScript definitions
+- `dist/index.mjs` - ES module
+- `dist/index.d.mts` - TypeScript definitions

--- a/packages/@poupe-tailwindcss/AGENTS.md
+++ b/packages/@poupe-tailwindcss/AGENTS.md
@@ -215,7 +215,7 @@ The package provides two pre-built CSS files in `src/assets/`:
 
 - **Hook**: `build:done` in `build.config.ts`
 - **Output**: `examples/*/output.css` files
-- **Command**: Uses `pnpx @tailwindcss/cli` for each example
+- **Command**: Uses `pnpm exec @tailwindcss/cli` for each example
 - **Purpose**: Human-viewable CSS files for browser testing
 
 #### Build Commands

--- a/packages/@poupe-theme-builder/AGENTS.md
+++ b/packages/@poupe-theme-builder/AGENTS.md
@@ -49,7 +49,7 @@ src/
 
 ## Build Configuration
 
-Exports three entry points via unbuild:
+Exports three entry points via obuild:
 
 - `index` - Main theme builder functionality
 - `core` - Core utilities and algorithms

--- a/packages/@poupe-theme-builder/CHANGELOG.md
+++ b/packages/@poupe-theme-builder/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `makeTheme` no longer silently routes `scheme: 'monochrome'` to
+  `content`. `makeThemeWithOptions` fell back via
+  `standardDynamicSchemes[scheme] || standardDynamicSchemes.content`,
+  collapsing `Variant.MONOCHROME` (=0) under JS truthiness. The
+  fallback uses `??`, so the unknown-key defence (against
+  TS-bypass / `any` callers) is preserved while every zero-valued
+  variant survives the lookup.
+
 ### Dependencies
 
 - `vitest` devDep `^3.2.4 → ^4.1.7`.

--- a/packages/@poupe-theme-builder/CHANGELOG.md
+++ b/packages/@poupe-theme-builder/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-05-25
+
 ### Fixed
 
 - `makeTheme` no longer silently routes `scheme: 'monochrome'` to

--- a/packages/@poupe-theme-builder/package.json
+++ b/packages/@poupe-theme-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/theme-builder",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "description": "Design token management and theme generation system for Poupe UI framework",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-theme-builder/src/theme/__tests__/theme-options.test.ts
+++ b/packages/@poupe-theme-builder/src/theme/__tests__/theme-options.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, expect, it } from 'vitest';
-import { Hct } from '../../core';
+import { Hct, Variant } from '../../core';
 import { makeTheme } from '../theme';
 
 describe('makeTheme with options', () => {
@@ -67,6 +67,16 @@ describe('makeTheme with options', () => {
 
       expect((theme.dark as any)['primary-hover']).toBeDefined();
       expect(theme.darkScheme.contrastLevel).toBe(0.2);
+    });
+  });
+
+  describe('scheme option', () => {
+    it('should route monochrome to MONOCHROME, not collapse to content', () => {
+      // Variant.MONOCHROME === 0 — JS truthiness on a numeric enum
+      // used to silently route the scheme through content.
+      const theme = makeTheme(colors, 'monochrome');
+      expect(theme.darkScheme.variant).toBe(Variant.MONOCHROME);
+      expect(theme.lightScheme.variant).toBe(Variant.MONOCHROME);
     });
   });
 

--- a/packages/@poupe-theme-builder/src/theme/theme.ts
+++ b/packages/@poupe-theme-builder/src/theme/theme.ts
@@ -133,7 +133,7 @@ function makeThemeWithOptions<K extends string>(
   const { source, corePalettes, extraPalettes, colors: colorOptions } = makeThemePalettes(colors);
   const { contrastLevel = 0, scheme = 'content' } = options;
 
-  const variant = standardDynamicSchemes[scheme] || standardDynamicSchemes.content;
+  const variant = standardDynamicSchemes[scheme] ?? standardDynamicSchemes.content;
   const darkScheme = makeDynamicScheme(source, variant, contrastLevel, true, corePalettes);
   const lightScheme = makeDynamicScheme(source, variant, contrastLevel, false, corePalettes);
 


### PR DESCRIPTION
## Summary

`@poupe/theme-builder` patch release plus a documentation refresh
that accumulated against the post-obuild, post-Nuxt4 state of the
workspace.

- **`release(@poupe/theme-builder): v0.10.4`** — promotes the
  monochrome-routing fix and the upstream `vitest` devDep bump
  from `[Unreleased]`.
- **`fix(@poupe/theme-builder): preserve zero-valued variants in
  scheme lookup`** — `makeTheme(_, 'monochrome')` was silently
  returning a `Variant.CONTENT` scheme for both dark and light
  branches: `Variant.MONOCHROME === 0` collapsed through a `||`
  fallback in `makeThemeWithOptions`. The fallback now uses `??`,
  so the defence against out-of-table keys (TS-bypass / `any`
  callers) survives while every zero-valued variant passes
  through unchanged. Regression row in `theme-options.test.ts`
  pins both `darkScheme.variant` and `lightScheme.variant` to
  `Variant.MONOCHROME`.
- **`docs(agents): refresh stale build-system + version drift`** —
  post #521 (obuild migration cohort) and #525 (vitest / vite /
  TypeScript bump), AGENTS.md still claimed unbuild for several
  packages, vitest `^3.2.4`, and `dist/index.cjs` artefacts that
  obuild does not emit. Root + three per-package AGENTS.md files
  brought back in line with the current toolchain.

## Consumer impact

Patch-only. No public API change. Callers using `scheme:
'monochrome'` recover the variant they asked for; everyone else
is unaffected. `workspace:^` consumers (`@poupe/tailwindcss`)
resolve through pnpm without metadata edits — `'monochrome'` is
not invoked from `@poupe/tailwindcss`'s default config, so no
downstream patch bump is justified.

## Test plan

- [ ] `pnpm precommit` (root) — full lint + type-check + build +
      vitest pass.
- [ ] `pnpm -F @poupe/theme-builder test` —
      `theme-options.test.ts` monochrome regression row asserts
      `Variant.MONOCHROME` on both schemes.
- [ ] Verify `pnpm view @poupe/theme-builder@0.10.4` is unpublished
      pre-merge (the `publish:maybe` script is idempotent on
      double-runs but a sanity check belongs in the gate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed monochrome color scheme routing in theme generation that was previously falling back to an unintended default.

* **Tests**
  * Added enhanced coverage for color scheme routing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poupe-ui/poupe/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->