### PR TITLE
Fix squircle corners + Button ripple; @poupe/nuxt v0.5.0 (Nuxt 4)

### DIFF
--- a/packages/@poupe-nuxt/CHANGELOG.md
+++ b/packages/@poupe-nuxt/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-25
+
+### Changed
+
+- Require Nuxt 4. `nuxt`, `@nuxt/kit`, and `@nuxt/schema`
+  bump `^3.21 → ^4.4`; `@nuxt/test-utils` lifts to `^4.0`.
+  The module now declares `peerDependencies: { nuxt: ^4.0.0 }`
+  so missing-host installs surface as peer mismatches, and
+  `meta.compatibility: { nuxt: ^4.0.0 }` so Nuxt's module
+  loader can refuse registration under a too-old host.
+  Consumers on Nuxt 3 should stay on `@poupe/nuxt@0.4.x`.
+
+### Dependencies
+
+- `@nuxt/icon` `^1.15 → ^2.2`.
+- `@nuxtjs/color-mode` `^3.5 → ^4.0`.
+
 ## [0.4.4] - 2026-05-23
 
 ### Fixed

--- a/packages/@poupe-nuxt/package.json
+++ b/packages/@poupe-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/nuxt",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "type": "module",
   "description": "Nuxt module for integrating Poupe UI framework with theme customization and components",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-tailwindcss/CHANGELOG.md
+++ b/packages/@poupe-tailwindcss/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-05-25
+
 ### Fixed
 
 - `shape-squircle-*` utilities now keep corner curves at a
@@ -29,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   helper — sub-pixel precision the mask rasteriser can't
   resolve anyway. Combined with the prefix drop, per-utility
   payload drops from ~4.2 KB to ~1.8 KB.
+- Refresh agent docs to use `pnpm exec @tailwindcss/cli`
+  instead of the deprecated `pnpx` invocation for the
+  example builder.
 
 ## [0.5.3] - 2026-05-23
 

--- a/packages/@poupe-tailwindcss/CHANGELOG.md
+++ b/packages/@poupe-tailwindcss/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `shape-squircle-*` utilities now keep corner curves at a
+  fixed pixel size at any element dimension. The previous
+  single-SVG mask scaled the 200×200 path to the element,
+  so wide containers (e.g. a 1216×632 Card) got 300+px
+  corners that clipped heading and edge content. `getSquircleStyles`
+  emits a 9-layer composite mask instead: four corner sub-SVGs
+  viewBox-cropped from the existing squircle path and sized
+  to the SHAPE_SCALE `rounded` value (12px for medium), plus
+  four solid edge fills and one centre fill that cover the
+  rest via `calc(100% - 2 * <r>)`. `full` keeps its pill /
+  circle behaviour at 50% corners.
+
+### Internal
+
+- Drop the `-webkit-mask-*` duplications. Unprefixed `mask-*`
+  is baseline since Safari 15.4 / 2022.
+- Round SVG path floats to 2 dp via a module-scope `r2`
+  helper — sub-pixel precision the mask rasteriser can't
+  resolve anyway. Combined with the prefix drop, per-utility
+  payload drops from ~4.2 KB to ~1.8 KB.
+
 ## [0.5.3] - 2026-05-23
 
 ### Dependencies

--- a/packages/@poupe-tailwindcss/package.json
+++ b/packages/@poupe-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/tailwindcss",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "description": "TailwindCSS v4 plugin for Poupe UI framework with theme customization support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-tailwindcss/src/assets/default.css
+++ b/packages/@poupe-tailwindcss/src/assets/default.css
@@ -853,12 +853,10 @@
   border-radius: var(--md-shape-extra-small, 4px);
 }
 @utility shape-squircle-extra-small {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-extra-small: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-extra-small, 4px);
@@ -868,12 +866,10 @@
   border-radius: var(--md-shape-small, 8px);
 }
 @utility shape-squircle-small {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09138999324 0 200 17.90861000676 200 40 L 200 160 C 200 182.09138999324 182.09138999324 200 160 200 L 40 200 C 17.90861000676 200 0 182.09138999324 0 160 L 0 40 C 0 17.90861000676 17.90861000676 0 40 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='160 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 160 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='160 160 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 8px 8px, 8px 0, 8px 100%, 0 8px, 100% 8px;
+  mask-size: 8px 8px, 8px 8px, 8px 8px, 8px 8px, calc(100% - 2 * 8px) calc(100% - 2 * 8px), calc(100% - 2 * 8px) 8px, calc(100% - 2 * 8px) 8px, 8px calc(100% - 2 * 8px), 8px calc(100% - 2 * 8px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09138999324 0 200 17.90861000676 200 40 L 200 160 C 200 182.09138999324 182.09138999324 200 160 200 L 40 200 C 17.90861000676 200 0 182.09138999324 0 160 L 0 40 C 0 17.90861000676 17.90861000676 0 40 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-small: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-small, 8px);
@@ -883,12 +879,10 @@
   border-radius: var(--md-shape-medium, 12px);
 }
 @utility shape-squircle-medium {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61423749155 0 200 22.385762508450004 200 50 L 200 150 C 200 177.61423749155 177.61423749155 200 150 200 L 50 200 C 22.385762508450004 200 0 177.61423749155 0 150 L 0 50 C 0 22.385762508450004 22.385762508450004 0 50 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='150 0 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 150 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='150 150 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 12px 12px, 12px 0, 12px 100%, 0 12px, 100% 12px;
+  mask-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px, calc(100% - 2 * 12px) calc(100% - 2 * 12px), calc(100% - 2 * 12px) 12px, calc(100% - 2 * 12px) 12px, 12px calc(100% - 2 * 12px), 12px calc(100% - 2 * 12px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61423749155 0 200 22.385762508450004 200 50 L 200 150 C 200 177.61423749155 177.61423749155 200 150 200 L 50 200 C 22.385762508450004 200 0 177.61423749155 0 150 L 0 50 C 0 22.385762508450004 22.385762508450004 0 50 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-medium: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-medium, 12px);
@@ -898,12 +892,10 @@
   border-radius: var(--md-shape-large, 16px);
 }
 @utility shape-squircle-large {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 16px 16px, 16px 0, 16px 100%, 0 16px, 100% 16px;
+  mask-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, calc(100% - 2 * 16px) calc(100% - 2 * 16px), calc(100% - 2 * 16px) 16px, calc(100% - 2 * 16px) 16px, 16px calc(100% - 2 * 16px), 16px calc(100% - 2 * 16px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-large: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-large, 16px);
@@ -913,12 +905,10 @@
   border-radius: var(--md-shape-extra-large, 28px);
 }
 @utility shape-squircle-extra-large {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.65993248817 0 200 31.34006751183 200 70 L 200 130 C 200 168.65993248817 168.65993248817 200 130 200 L 70 200 C 31.34006751183 200 0 168.65993248817 0 130 L 0 70 C 0 31.34006751183 31.34006751183 0 70 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='130 0 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 130 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='130 130 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 28px 28px, 28px 0, 28px 100%, 0 28px, 100% 28px;
+  mask-size: 28px 28px, 28px 28px, 28px 28px, 28px 28px, calc(100% - 2 * 28px) calc(100% - 2 * 28px), calc(100% - 2 * 28px) 28px, calc(100% - 2 * 28px) 28px, 28px calc(100% - 2 * 28px), 28px calc(100% - 2 * 28px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.65993248817 0 200 31.34006751183 200 70 L 200 130 C 200 168.65993248817 168.65993248817 200 130 200 L 70 200 C 31.34006751183 200 0 168.65993248817 0 130 L 0 70 C 0 31.34006751183 31.34006751183 0 70 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-extra-large: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-extra-large, 28px);
@@ -928,12 +918,10 @@
   border-radius: var(--md-shape-full, 9999px);
 }
 @utility shape-squircle-full {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 50% 50%, 50% 0, 50% 100%, 0 50%, 100% 50%;
+  mask-size: 50% 50%, 50% 50%, 50% 50%, 50% 50%, calc(100% - 2 * 50%) calc(100% - 2 * 50%), calc(100% - 2 * 50%) 50%, calc(100% - 2 * 50%) 50%, 50% calc(100% - 2 * 50%), 50% calc(100% - 2 * 50%);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-full: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-full, 9999px);
@@ -949,12 +937,10 @@
   border-radius: var(--md-shape-button, var(--md-shape-full, 9999px));
 }
 @utility shape-squircle-button {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 50% 50%, 50% 0, 50% 100%, 0 50%, 100% 50%;
+  mask-size: 50% 50%, 50% 50%, 50% 50%, 50% 50%, calc(100% - 2 * 50%) calc(100% - 2 * 50%), calc(100% - 2 * 50%) 50%, calc(100% - 2 * 50%) 50%, 50% calc(100% - 2 * 50%), 50% calc(100% - 2 * 50%);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-button: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-button, var(--md-shape-full, 9999px));
@@ -964,12 +950,10 @@
   border-radius: var(--md-shape-fab, var(--md-shape-large, 16px));
 }
 @utility shape-squircle-fab {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 16px 16px, 16px 0, 16px 100%, 0 16px, 100% 16px;
+  mask-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, calc(100% - 2 * 16px) calc(100% - 2 * 16px), calc(100% - 2 * 16px) 16px, calc(100% - 2 * 16px) 16px, 16px calc(100% - 2 * 16px), 16px calc(100% - 2 * 16px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-fab: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-fab, var(--md-shape-large, 16px));
@@ -979,12 +963,10 @@
   border-radius: var(--md-shape-chip, var(--md-shape-small, 8px));
 }
 @utility shape-squircle-chip {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09138999324 0 200 17.90861000676 200 40 L 200 160 C 200 182.09138999324 182.09138999324 200 160 200 L 40 200 C 17.90861000676 200 0 182.09138999324 0 160 L 0 40 C 0 17.90861000676 17.90861000676 0 40 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='160 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 160 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='160 160 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 8px 8px, 8px 0, 8px 100%, 0 8px, 100% 8px;
+  mask-size: 8px 8px, 8px 8px, 8px 8px, 8px 8px, calc(100% - 2 * 8px) calc(100% - 2 * 8px), calc(100% - 2 * 8px) 8px, calc(100% - 2 * 8px) 8px, 8px calc(100% - 2 * 8px), 8px calc(100% - 2 * 8px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09138999324 0 200 17.90861000676 200 40 L 200 160 C 200 182.09138999324 182.09138999324 200 160 200 L 40 200 C 17.90861000676 200 0 182.09138999324 0 160 L 0 40 C 0 17.90861000676 17.90861000676 0 40 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-chip: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-chip, var(--md-shape-small, 8px));
@@ -994,12 +976,10 @@
   border-radius: var(--md-shape-icon-button, var(--md-shape-full, 9999px));
 }
 @utility shape-squircle-icon-button {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 50% 50%, 50% 0, 50% 100%, 0 50%, 100% 50%;
+  mask-size: 50% 50%, 50% 50%, 50% 50%, 50% 50%, calc(100% - 2 * 50%) calc(100% - 2 * 50%), calc(100% - 2 * 50%) 50%, calc(100% - 2 * 50%) 50%, 50% calc(100% - 2 * 50%), 50% calc(100% - 2 * 50%);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-icon-button: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-icon-button, var(--md-shape-full, 9999px));
@@ -1009,12 +989,10 @@
   border-radius: var(--md-shape-card, var(--md-shape-medium, 12px));
 }
 @utility shape-squircle-card {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61423749155 0 200 22.385762508450004 200 50 L 200 150 C 200 177.61423749155 177.61423749155 200 150 200 L 50 200 C 22.385762508450004 200 0 177.61423749155 0 150 L 0 50 C 0 22.385762508450004 22.385762508450004 0 50 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='150 0 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 150 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='150 150 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 12px 12px, 12px 0, 12px 100%, 0 12px, 100% 12px;
+  mask-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px, calc(100% - 2 * 12px) calc(100% - 2 * 12px), calc(100% - 2 * 12px) 12px, calc(100% - 2 * 12px) 12px, 12px calc(100% - 2 * 12px), 12px calc(100% - 2 * 12px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61423749155 0 200 22.385762508450004 200 50 L 200 150 C 200 177.61423749155 177.61423749155 200 150 200 L 50 200 C 22.385762508450004 200 0 177.61423749155 0 150 L 0 50 C 0 22.385762508450004 22.385762508450004 0 50 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-card: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-card, var(--md-shape-medium, 12px));
@@ -1024,12 +1002,10 @@
   border-radius: var(--md-shape-dialog, var(--md-shape-extra-large, 28px));
 }
 @utility shape-squircle-dialog {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.65993248817 0 200 31.34006751183 200 70 L 200 130 C 200 168.65993248817 168.65993248817 200 130 200 L 70 200 C 31.34006751183 200 0 168.65993248817 0 130 L 0 70 C 0 31.34006751183 31.34006751183 0 70 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='130 0 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 130 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='130 130 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 28px 28px, 28px 0, 28px 100%, 0 28px, 100% 28px;
+  mask-size: 28px 28px, 28px 28px, 28px 28px, 28px 28px, calc(100% - 2 * 28px) calc(100% - 2 * 28px), calc(100% - 2 * 28px) 28px, calc(100% - 2 * 28px) 28px, 28px calc(100% - 2 * 28px), 28px calc(100% - 2 * 28px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.65993248817 0 200 31.34006751183 200 70 L 200 130 C 200 168.65993248817 168.65993248817 200 130 200 L 70 200 C 31.34006751183 200 0 168.65993248817 0 130 L 0 70 C 0 31.34006751183 31.34006751183 0 70 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-dialog: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-dialog, var(--md-shape-extra-large, 28px));
@@ -1039,12 +1015,10 @@
   border-radius: var(--md-shape-menu, var(--md-shape-extra-small, 4px));
 }
 @utility shape-squircle-menu {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-menu: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-menu, var(--md-shape-extra-small, 4px));
@@ -1054,12 +1028,10 @@
   border-radius: var(--md-shape-snackbar, var(--md-shape-extra-small, 4px));
 }
 @utility shape-squircle-snackbar {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-snackbar: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-snackbar, var(--md-shape-extra-small, 4px));
@@ -1069,12 +1041,10 @@
   border-radius: var(--md-shape-tooltip, var(--md-shape-extra-small, 4px));
 }
 @utility shape-squircle-tooltip {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-tooltip: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-tooltip, var(--md-shape-extra-small, 4px));
@@ -1084,12 +1054,10 @@
   border-radius: var(--md-shape-text-field, var(--md-shape-extra-small, 4px));
 }
 @utility shape-squircle-text-field {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-text-field: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-text-field, var(--md-shape-extra-small, 4px));
@@ -1099,12 +1067,10 @@
   border-radius: var(--md-shape-search, var(--md-shape-full, 9999px));
 }
 @utility shape-squircle-search {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 50% 50%, 50% 0, 50% 100%, 0 50%, 100% 50%;
+  mask-size: 50% 50%, 50% 50%, 50% 50%, 50% 50%, calc(100% - 2 * 50%) calc(100% - 2 * 50%), calc(100% - 2 * 50%) 50%, calc(100% - 2 * 50%) 50%, 50% calc(100% - 2 * 50%), 50% calc(100% - 2 * 50%);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-search: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-search, var(--md-shape-full, 9999px));
@@ -1120,12 +1086,10 @@
   border-radius: var(--md-shape-navigation-drawer, var(--md-shape-large, 16px));
 }
 @utility shape-squircle-navigation-drawer {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 16px 16px, 16px 0, 16px 100%, 0 16px, 100% 16px;
+  mask-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, calc(100% - 2 * 16px) calc(100% - 2 * 16px), calc(100% - 2 * 16px) 16px, calc(100% - 2 * 16px) 16px, 16px calc(100% - 2 * 16px), 16px calc(100% - 2 * 16px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-navigation-drawer: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-navigation-drawer, var(--md-shape-large, 16px));

--- a/packages/@poupe-tailwindcss/src/assets/style.css
+++ b/packages/@poupe-tailwindcss/src/assets/style.css
@@ -724,12 +724,10 @@
   border-radius: var(--md-shape-extra-small, 4px);
 }
 @utility shape-squircle-extra-small {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-extra-small: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-extra-small, 4px);
@@ -739,12 +737,10 @@
   border-radius: var(--md-shape-small, 8px);
 }
 @utility shape-squircle-small {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09138999324 0 200 17.90861000676 200 40 L 200 160 C 200 182.09138999324 182.09138999324 200 160 200 L 40 200 C 17.90861000676 200 0 182.09138999324 0 160 L 0 40 C 0 17.90861000676 17.90861000676 0 40 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='160 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 160 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='160 160 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 8px 8px, 8px 0, 8px 100%, 0 8px, 100% 8px;
+  mask-size: 8px 8px, 8px 8px, 8px 8px, 8px 8px, calc(100% - 2 * 8px) calc(100% - 2 * 8px), calc(100% - 2 * 8px) 8px, calc(100% - 2 * 8px) 8px, 8px calc(100% - 2 * 8px), 8px calc(100% - 2 * 8px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09138999324 0 200 17.90861000676 200 40 L 200 160 C 200 182.09138999324 182.09138999324 200 160 200 L 40 200 C 17.90861000676 200 0 182.09138999324 0 160 L 0 40 C 0 17.90861000676 17.90861000676 0 40 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-small: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-small, 8px);
@@ -754,12 +750,10 @@
   border-radius: var(--md-shape-medium, 12px);
 }
 @utility shape-squircle-medium {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61423749155 0 200 22.385762508450004 200 50 L 200 150 C 200 177.61423749155 177.61423749155 200 150 200 L 50 200 C 22.385762508450004 200 0 177.61423749155 0 150 L 0 50 C 0 22.385762508450004 22.385762508450004 0 50 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='150 0 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 150 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='150 150 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 12px 12px, 12px 0, 12px 100%, 0 12px, 100% 12px;
+  mask-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px, calc(100% - 2 * 12px) calc(100% - 2 * 12px), calc(100% - 2 * 12px) 12px, calc(100% - 2 * 12px) 12px, 12px calc(100% - 2 * 12px), 12px calc(100% - 2 * 12px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61423749155 0 200 22.385762508450004 200 50 L 200 150 C 200 177.61423749155 177.61423749155 200 150 200 L 50 200 C 22.385762508450004 200 0 177.61423749155 0 150 L 0 50 C 0 22.385762508450004 22.385762508450004 0 50 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-medium: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-medium, 12px);
@@ -769,12 +763,10 @@
   border-radius: var(--md-shape-large, 16px);
 }
 @utility shape-squircle-large {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 16px 16px, 16px 0, 16px 100%, 0 16px, 100% 16px;
+  mask-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, calc(100% - 2 * 16px) calc(100% - 2 * 16px), calc(100% - 2 * 16px) 16px, calc(100% - 2 * 16px) 16px, 16px calc(100% - 2 * 16px), 16px calc(100% - 2 * 16px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-large: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-large, 16px);
@@ -784,12 +776,10 @@
   border-radius: var(--md-shape-extra-large, 28px);
 }
 @utility shape-squircle-extra-large {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.65993248817 0 200 31.34006751183 200 70 L 200 130 C 200 168.65993248817 168.65993248817 200 130 200 L 70 200 C 31.34006751183 200 0 168.65993248817 0 130 L 0 70 C 0 31.34006751183 31.34006751183 0 70 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='130 0 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 130 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='130 130 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 28px 28px, 28px 0, 28px 100%, 0 28px, 100% 28px;
+  mask-size: 28px 28px, 28px 28px, 28px 28px, 28px 28px, calc(100% - 2 * 28px) calc(100% - 2 * 28px), calc(100% - 2 * 28px) 28px, calc(100% - 2 * 28px) 28px, 28px calc(100% - 2 * 28px), 28px calc(100% - 2 * 28px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.65993248817 0 200 31.34006751183 200 70 L 200 130 C 200 168.65993248817 168.65993248817 200 130 200 L 70 200 C 31.34006751183 200 0 168.65993248817 0 130 L 0 70 C 0 31.34006751183 31.34006751183 0 70 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-extra-large: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-extra-large, 28px);
@@ -799,12 +789,10 @@
   border-radius: var(--md-shape-full, 9999px);
 }
 @utility shape-squircle-full {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 50% 50%, 50% 0, 50% 100%, 0 50%, 100% 50%;
+  mask-size: 50% 50%, 50% 50%, 50% 50%, 50% 50%, calc(100% - 2 * 50%) calc(100% - 2 * 50%), calc(100% - 2 * 50%) 50%, calc(100% - 2 * 50%) 50%, 50% calc(100% - 2 * 50%), 50% calc(100% - 2 * 50%);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-full: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-full, 9999px);
@@ -820,12 +808,10 @@
   border-radius: var(--md-shape-button, var(--md-shape-full, 9999px));
 }
 @utility shape-squircle-button {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 50% 50%, 50% 0, 50% 100%, 0 50%, 100% 50%;
+  mask-size: 50% 50%, 50% 50%, 50% 50%, 50% 50%, calc(100% - 2 * 50%) calc(100% - 2 * 50%), calc(100% - 2 * 50%) 50%, calc(100% - 2 * 50%) 50%, 50% calc(100% - 2 * 50%), 50% calc(100% - 2 * 50%);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-button: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-button, var(--md-shape-full, 9999px));
@@ -835,12 +821,10 @@
   border-radius: var(--md-shape-fab, var(--md-shape-large, 16px));
 }
 @utility shape-squircle-fab {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 16px 16px, 16px 0, 16px 100%, 0 16px, 100% 16px;
+  mask-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, calc(100% - 2 * 16px) calc(100% - 2 * 16px), calc(100% - 2 * 16px) 16px, calc(100% - 2 * 16px) 16px, 16px calc(100% - 2 * 16px), 16px calc(100% - 2 * 16px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-fab: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-fab, var(--md-shape-large, 16px));
@@ -850,12 +834,10 @@
   border-radius: var(--md-shape-chip, var(--md-shape-small, 8px));
 }
 @utility shape-squircle-chip {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09138999324 0 200 17.90861000676 200 40 L 200 160 C 200 182.09138999324 182.09138999324 200 160 200 L 40 200 C 17.90861000676 200 0 182.09138999324 0 160 L 0 40 C 0 17.90861000676 17.90861000676 0 40 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='160 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 160 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='160 160 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09 0 200 17.91 200 40 L 200 160 C 200 182.09 182.09 200 160 200 L 40 200 C 17.91 200 0 182.09 0 160 L 0 40 C 0 17.91 17.91 0 40 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 8px 8px, 8px 0, 8px 100%, 0 8px, 100% 8px;
+  mask-size: 8px 8px, 8px 8px, 8px 8px, 8px 8px, calc(100% - 2 * 8px) calc(100% - 2 * 8px), calc(100% - 2 * 8px) 8px, calc(100% - 2 * 8px) 8px, 8px calc(100% - 2 * 8px), 8px calc(100% - 2 * 8px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 40 0 L 160 0 C 182.09138999324 0 200 17.90861000676 200 40 L 200 160 C 200 182.09138999324 182.09138999324 200 160 200 L 40 200 C 17.90861000676 200 0 182.09138999324 0 160 L 0 40 C 0 17.90861000676 17.90861000676 0 40 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-chip: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-chip, var(--md-shape-small, 8px));
@@ -865,12 +847,10 @@
   border-radius: var(--md-shape-icon-button, var(--md-shape-full, 9999px));
 }
 @utility shape-squircle-icon-button {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 50% 50%, 50% 0, 50% 100%, 0 50%, 100% 50%;
+  mask-size: 50% 50%, 50% 50%, 50% 50%, 50% 50%, calc(100% - 2 * 50%) calc(100% - 2 * 50%), calc(100% - 2 * 50%) 50%, calc(100% - 2 * 50%) 50%, 50% calc(100% - 2 * 50%), 50% calc(100% - 2 * 50%);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-icon-button: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-icon-button, var(--md-shape-full, 9999px));
@@ -880,12 +860,10 @@
   border-radius: var(--md-shape-card, var(--md-shape-medium, 12px));
 }
 @utility shape-squircle-card {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61423749155 0 200 22.385762508450004 200 50 L 200 150 C 200 177.61423749155 177.61423749155 200 150 200 L 50 200 C 22.385762508450004 200 0 177.61423749155 0 150 L 0 50 C 0 22.385762508450004 22.385762508450004 0 50 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='150 0 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 150 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='150 150 50 50' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61 0 200 22.39 200 50 L 200 150 C 200 177.61 177.61 200 150 200 L 50 200 C 22.39 200 0 177.61 0 150 L 0 50 C 0 22.39 22.39 0 50 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 12px 12px, 12px 0, 12px 100%, 0 12px, 100% 12px;
+  mask-size: 12px 12px, 12px 12px, 12px 12px, 12px 12px, calc(100% - 2 * 12px) calc(100% - 2 * 12px), calc(100% - 2 * 12px) 12px, calc(100% - 2 * 12px) 12px, 12px calc(100% - 2 * 12px), 12px calc(100% - 2 * 12px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 50 0 L 150 0 C 177.61423749155 0 200 22.385762508450004 200 50 L 200 150 C 200 177.61423749155 177.61423749155 200 150 200 L 50 200 C 22.385762508450004 200 0 177.61423749155 0 150 L 0 50 C 0 22.385762508450004 22.385762508450004 0 50 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-card: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-card, var(--md-shape-medium, 12px));
@@ -895,12 +873,10 @@
   border-radius: var(--md-shape-dialog, var(--md-shape-extra-large, 28px));
 }
 @utility shape-squircle-dialog {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.65993248817 0 200 31.34006751183 200 70 L 200 130 C 200 168.65993248817 168.65993248817 200 130 200 L 70 200 C 31.34006751183 200 0 168.65993248817 0 130 L 0 70 C 0 31.34006751183 31.34006751183 0 70 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='130 0 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 130 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='130 130 70 70' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.66 0 200 31.34 200 70 L 200 130 C 200 168.66 168.66 200 130 200 L 70 200 C 31.34 200 0 168.66 0 130 L 0 70 C 0 31.34 31.34 0 70 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 28px 28px, 28px 0, 28px 100%, 0 28px, 100% 28px;
+  mask-size: 28px 28px, 28px 28px, 28px 28px, 28px 28px, calc(100% - 2 * 28px) calc(100% - 2 * 28px), calc(100% - 2 * 28px) 28px, calc(100% - 2 * 28px) 28px, 28px calc(100% - 2 * 28px), 28px calc(100% - 2 * 28px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 70 0 L 130 0 C 168.65993248817 0 200 31.34006751183 200 70 L 200 130 C 200 168.65993248817 168.65993248817 200 130 200 L 70 200 C 31.34006751183 200 0 168.65993248817 0 130 L 0 70 C 0 31.34006751183 31.34006751183 0 70 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-dialog: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-dialog, var(--md-shape-extra-large, 28px));
@@ -910,12 +886,10 @@
   border-radius: var(--md-shape-menu, var(--md-shape-extra-small, 4px));
 }
 @utility shape-squircle-menu {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-menu: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-menu, var(--md-shape-extra-small, 4px));
@@ -925,12 +899,10 @@
   border-radius: var(--md-shape-snackbar, var(--md-shape-extra-small, 4px));
 }
 @utility shape-squircle-snackbar {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-snackbar: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-snackbar, var(--md-shape-extra-small, 4px));
@@ -940,12 +912,10 @@
   border-radius: var(--md-shape-tooltip, var(--md-shape-extra-small, 4px));
 }
 @utility shape-squircle-tooltip {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-tooltip: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-tooltip, var(--md-shape-extra-small, 4px));
@@ -955,12 +925,10 @@
   border-radius: var(--md-shape-text-field, var(--md-shape-extra-small, 4px));
 }
 @utility shape-squircle-text-field {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='170 170 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.57 0 200 13.43 200 30 L 200 170 C 200 186.57 186.57 200 170 200 L 30 200 C 13.43 200 0 186.57 0 170 L 0 30 C 0 13.43 13.43 0 30 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 4px 4px, 4px 0, 4px 100%, 0 4px, 100% 4px;
+  mask-size: 4px 4px, 4px 4px, 4px 4px, 4px 4px, calc(100% - 2 * 4px) calc(100% - 2 * 4px), calc(100% - 2 * 4px) 4px, calc(100% - 2 * 4px) 4px, 4px calc(100% - 2 * 4px), 4px calc(100% - 2 * 4px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 30 0 L 170 0 C 186.56854249493 0 200 13.43145750507 200 30 L 200 170 C 200 186.56854249493 186.56854249493 200 170 200 L 30 200 C 13.43145750507 200 0 186.56854249493 0 170 L 0 30 C 0 13.43145750507 13.43145750507 0 30 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-text-field: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-text-field, var(--md-shape-extra-small, 4px));
@@ -970,12 +938,10 @@
   border-radius: var(--md-shape-search, var(--md-shape-full, 9999px));
 }
 @utility shape-squircle-search {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='100 100 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 50% 50%, 50% 0, 50% 100%, 0 50%, 100% 50%;
+  mask-size: 50% 50%, 50% 50%, 50% 50%, 50% 50%, calc(100% - 2 * 50%) calc(100% - 2 * 50%), calc(100% - 2 * 50%) 50%, calc(100% - 2 * 50%) 50%, 50% calc(100% - 2 * 50%), 50% calc(100% - 2 * 50%);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 100 0 A 100 100 0 0 1 200 100 A 100 100 0 0 1 100 200 A 100 100 0 0 1 0 100 A 100 100 0 0 1 100 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-search: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-search, var(--md-shape-full, 9999px));
@@ -991,12 +957,10 @@
   border-radius: var(--md-shape-navigation-drawer, var(--md-shape-large, 16px));
 }
 @utility shape-squircle-navigation-drawer {
-  mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  mask-size: 100% 100%;
+  mask-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='0 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), url("data:image/svg+xml,%3Csvg viewBox='140 140 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.14 0 200 26.86 200 60 L 200 140 C 200 173.14 173.14 200 140 200 L 60 200 C 26.86 200 0 173.14 0 140 L 0 60 C 0 26.86 26.86 0 60 0 Z' fill='black'/%3E%3C/svg%3E"), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000), linear-gradient(#000, #000);
+  mask-position: top left, top right, bottom left, bottom right, 16px 16px, 16px 0, 16px 100%, 0 16px, 100% 16px;
+  mask-size: 16px 16px, 16px 16px, 16px 16px, 16px 16px, calc(100% - 2 * 16px) calc(100% - 2 * 16px), calc(100% - 2 * 16px) 16px, calc(100% - 2 * 16px) 16px, 16px calc(100% - 2 * 16px), 16px calc(100% - 2 * 16px);
   mask-repeat: no-repeat;
-  -webkit-mask-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M 60 0 L 140 0 C 173.13708498986 0 200 26.86291501014 200 60 L 200 140 C 200 173.13708498986 173.13708498986 200 140 200 L 60 200 C 26.86291501014 200 0 173.13708498986 0 140 L 0 60 C 0 26.86291501014 26.86291501014 0 60 0 Z' fill='black'/%3E%3C/svg%3E");
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
   --md-shape-family-navigation-drawer: squircle;
   @supports not (mask-image: url()) {
     border-radius: var(--md-shape-navigation-drawer, var(--md-shape-large, 16px));

--- a/packages/@poupe-tailwindcss/src/theme/__tests__/components.test.ts
+++ b/packages/@poupe-tailwindcss/src/theme/__tests__/components.test.ts
@@ -475,7 +475,7 @@ describe('makeShapeComponents', () => {
     expect(maskImage).toContain('M ');
     expect(maskImage).not.toContain('NaN');
 
-    // Verify all squircle shapes have valid mask images
+    // Verify all squircle shapes have valid mask-image entries
     const squircleKeys = Object.keys(result).filter((key) => key.includes('squircle'));
     for (const key of squircleKeys) {
       const shape = result[key];
@@ -486,5 +486,70 @@ describe('makeShapeComponents', () => {
     }
 
     // Test values are all within valid range (0-2) per MD3 Expressive design
+  });
+
+  it('should emit a 9-layer composite mask for size-aware corners', () => {
+    const theme = makeThemeFromPartialOptions({ themePrefix: 'md-' });
+    const result = makeShapeComponents(theme);
+    const squircleMedium = result['.shape-squircle-medium'];
+
+    // Composite shape: 4 corner SVGs + 4 edge fills + 1 centre fill.
+    const maskImage = squircleMedium['mask-image'] as string;
+    expect(maskImage.match(/url\(/g)).toHaveLength(4);
+    expect(maskImage.match(/linear-gradient/g)).toHaveLength(5);
+
+    // Each corner SVG crops the same 200x200 path via a distinct
+    // viewBox. For squircle='1' (medium), r = 50 in SVG units.
+    expect(maskImage).toContain('viewBox=\'0 0 50 50\'');
+    expect(maskImage).toContain('viewBox=\'150 0 50 50\'');
+    expect(maskImage).toContain('viewBox=\'0 150 50 50\'');
+    expect(maskImage).toContain('viewBox=\'150 150 50 50\'');
+
+    // Corners anchor to the four element corners; edges + centre stretch.
+    const maskPosition = squircleMedium['mask-position'] as string;
+    expect(maskPosition).toContain('top left');
+    expect(maskPosition).toContain('top right');
+    expect(maskPosition).toContain('bottom left');
+    expect(maskPosition).toContain('bottom right');
+
+    // Corner regions hold the `rounded` pixel size; centre fills the rest.
+    const maskSize = squircleMedium['mask-size'] as string;
+    expect(maskSize).toContain('12px 12px');
+    expect(maskSize).toContain('calc(100% - 2 * 12px)');
+
+    expect(squircleMedium['mask-repeat']).toBe('no-repeat');
+  });
+
+  it('should render shape-squircle-full as a pill with 50% corners', () => {
+    const theme = makeThemeFromPartialOptions({ themePrefix: 'md-' });
+    const result = makeShapeComponents(theme);
+    const squircleFull = result['.shape-squircle-full'];
+
+    // 9999px is treated as a pill request: corners sized to 50% so the
+    // four quadrants tile the element at any aspect ratio.
+    const maskSize = squircleFull['mask-size'] as string;
+    expect(maskSize).toContain('50% 50%');
+    // calc(100% - 2 * 50%) collapses centre + edges to zero size,
+    // leaving the four corner SVGs to cover the element.
+    expect(maskSize).toContain('calc(100% - 2 * 50%)');
+  });
+
+  it('should not emit -webkit-mask-* prefix duplications', () => {
+    // mask-image / mask-position / mask-size / mask-repeat are baseline
+    // since Safari 15.4 (2022); the -webkit-* prefix was dropped to halve
+    // the per-utility payload.
+    const theme = makeThemeFromPartialOptions({ themePrefix: 'md-' });
+    const result = makeShapeComponents(theme);
+    const squircleKeys = Object.keys(result).filter(
+      (k) => k.includes('squircle-'),
+    );
+
+    for (const key of squircleKeys) {
+      const shape = result[key];
+      expect(shape['-webkit-mask-image']).toBeUndefined();
+      expect(shape['-webkit-mask-size']).toBeUndefined();
+      expect(shape['-webkit-mask-position']).toBeUndefined();
+      expect(shape['-webkit-mask-repeat']).toBeUndefined();
+    }
   });
 });

--- a/packages/@poupe-tailwindcss/src/theme/components.ts
+++ b/packages/@poupe-tailwindcss/src/theme/components.ts
@@ -525,20 +525,94 @@ export const SHAPE_SCALE = {
 export type ShapeScaleKey = keyof typeof SHAPE_SCALE;
 
 /**
- * Generates CSS properties for a squircle shape
- * Uses CSS mask with SVG path for a smooth iOS-style squircle
+ * Generates CSS properties for a squircle shape.
+ *
+ * Implements a size-aware composite mask: four corner SVGs (each
+ * cropped to one corner of the squircle path via `viewBox`) plus
+ * four solid edge layers and one solid centre layer. The corners
+ * stay at a fixed CSS-pixel size; the edges and centre stretch to
+ * fill the rest of the element. A naive single-layer mask stretched
+ * to fill the box lets the corner inset grow proportionally to the
+ * element, producing stadium-shaped curves at large widths that
+ * clip heading and edge content behind the corner. `mask-border`
+ * would be the canonical single-property fix, but Chrome's
+ * `-webkit-mask-box-image` ignores the `fill` slice keyword and
+ * leaves the centre region transparent.
+ *
+ * @param smoothing - MD3 smoothing factor (0 = rectangle,
+ *   1 = squircle, 2 = circle). Drives the SVG path corner inset.
+ * @param rounded - CSS pixel value (e.g. `12px`) for the on-element
+ *   corner size. `9999px` is treated as a pill request and rendered
+ *   with `50%` corners, giving a true pill at any aspect ratio.
  */
-function getSquircleStyles(smoothing: string): CSSRuleObject {
-  // Smoothing value of 1 = standard squircle, higher = more rounded
-  const s = smoothing;
-  return {
-    'mask-image': `url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='${getSquirclePath(s)}' fill='black'/%3E%3C/svg%3E")`,
-    'mask-size': '100% 100%',
-    'mask-repeat': 'no-repeat',
-    '-webkit-mask-image': `url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='${getSquirclePath(s)}' fill='black'/%3E%3C/svg%3E")`,
-    '-webkit-mask-size': '100% 100%',
-    '-webkit-mask-repeat': 'no-repeat',
+function getSquircleStyles(smoothing: string, rounded: string): CSSRuleObject {
+  const path = getSquirclePath(smoothing);
+
+  // Corner inset in the 200×200 SVG path. The path's curve lives in
+  // the first/last `r` units on each axis; the centre and straight
+  // edges are uniform fill. Cropping to an `r × r` corner viewBox
+  // gives us just the curve to use as a corner mask.
+  const s = Number.parseFloat(smoothing);
+  const validS = Number.isNaN(s) || s < 0 ? 0.6 : Math.min(s, 2);
+  const r = Math.round((validS / 2) * 100);
+
+  const w = rounded === '9999px' ? '50%' : rounded;
+  const inner = `calc(100% - 2 * ${w})`;
+
+  const cornerSvg = (x: number, y: number) =>
+    `url("data:image/svg+xml,%3Csvg viewBox='${x} ${y} ${r} ${r}' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='${path}' fill='black'/%3E%3C/svg%3E")`;
+
+  const layers = {
+    image: [
+      cornerSvg(0, 0),
+      cornerSvg(200 - r, 0),
+      cornerSvg(0, 200 - r),
+      cornerSvg(200 - r, 200 - r),
+      'linear-gradient(#000, #000)', // centre
+      'linear-gradient(#000, #000)', // top edge
+      'linear-gradient(#000, #000)', // bottom edge
+      'linear-gradient(#000, #000)', // left edge
+      'linear-gradient(#000, #000)', // right edge
+    ].join(', '),
+    position: [
+      'top left',
+      'top right',
+      'bottom left',
+      'bottom right',
+      `${w} ${w}`,
+      `${w} 0`,
+      `${w} 100%`,
+      `0 ${w}`,
+      `100% ${w}`,
+    ].join(', '),
+    size: [
+      `${w} ${w}`,
+      `${w} ${w}`,
+      `${w} ${w}`,
+      `${w} ${w}`,
+      `${inner} ${inner}`,
+      `${inner} ${w}`,
+      `${inner} ${w}`,
+      `${w} ${inner}`,
+      `${w} ${inner}`,
+    ].join(', '),
   };
+
+  return {
+    'mask-image': layers.image,
+    'mask-position': layers.position,
+    'mask-size': layers.size,
+    'mask-repeat': 'no-repeat',
+  };
+}
+
+/**
+ * Round to 2 decimal places — sub-pixel precision the rendered
+ * mask can't resolve anyway, and the trailing `0.385762508450004`
+ * digits from float maths bloat every embedded SVG payload.
+ */
+function r2(v: number): number {
+  return +v.toFixed(2);
 }
 
 /**
@@ -586,8 +660,8 @@ function getSquirclePath(smoothing: string): string {
   const cornerX = Math.max(0, Math.min(100, r));
   const cornerY = Math.max(0, Math.min(100, r));
 
-  // Generate path
-  return `M ${cornerX} 0 L ${200 - cornerX} 0 C ${200 - cornerX + controlOffset} 0 200 ${cornerY - controlOffset} 200 ${cornerY} L 200 ${200 - cornerY} C 200 ${200 - cornerY + controlOffset} ${200 - cornerX + controlOffset} 200 ${200 - cornerX} 200 L ${cornerX} 200 C ${cornerX - controlOffset} 200 0 ${200 - cornerY + controlOffset} 0 ${200 - cornerY} L 0 ${cornerY} C 0 ${cornerY - controlOffset} ${cornerX - controlOffset} 0 ${cornerX} 0 Z`;
+  // Generate path; floats rounded to 2 dp via module-scope `r2`.
+  return `M ${cornerX} 0 L ${200 - cornerX} 0 C ${r2(200 - cornerX + controlOffset)} 0 200 ${r2(cornerY - controlOffset)} 200 ${cornerY} L 200 ${200 - cornerY} C 200 ${r2(200 - cornerY + controlOffset)} ${r2(200 - cornerX + controlOffset)} 200 ${200 - cornerX} 200 L ${cornerX} 200 C ${r2(cornerX - controlOffset)} 200 0 ${r2(200 - cornerY + controlOffset)} 0 ${200 - cornerY} L 0 ${cornerY} C 0 ${r2(cornerY - controlOffset)} ${r2(cornerX - controlOffset)} 0 ${cornerX} 0 Z`;
 }
 
 /**
@@ -621,10 +695,11 @@ export function makeShapeComponents(theme: Readonly<Theme>): Record<string, CSSR
     // Squircle shapes for MD3 Expressive
     if (scale !== 'none') {
       components[`.${shapePrefix}squircle-${scale}`] = {
-        ...getSquircleStyles(values.squircle),
+        ...getSquircleStyles(values.squircle, values.rounded),
         // Store shape family for component reference
         [`--${themePrefix}shape-family-${scale}`]: 'squircle',
-        // Fallback to rounded corners for browsers that don't support mask
+        // Fallback for browsers without CSS mask-image support.
+        // Renders a plain rounded rectangle instead of a squircle.
         '@supports not (mask-image: url())': {
           'border-radius': `var(${shapeVariable}, ${values.rounded})`,
         },
@@ -679,10 +754,10 @@ export function makeShapeComponents(theme: Readonly<Theme>): Record<string, CSSR
     // Squircle component shapes for MD3 Expressive
     if (defaultScale !== 'none') {
       components[`.${shapePrefix}squircle-${component}`] = {
-        ...getSquircleStyles(SHAPE_SCALE[defaultScale].squircle),
+        ...getSquircleStyles(SHAPE_SCALE[defaultScale].squircle, SHAPE_SCALE[defaultScale].rounded),
         // Store component shape family
         [`--${themePrefix}shape-family-${component}`]: 'squircle',
-        // Fallback to rounded corners for browsers that don't support mask
+        // Fallback for browsers without CSS mask-image support.
         '@supports not (mask-image: url())': {
           'border-radius': `var(${shapeVariable}, var(${defaultVariable}, ${SHAPE_SCALE[defaultScale].rounded}))`,
         },

--- a/packages/@poupe-vue/CHANGELOG.md
+++ b/packages/@poupe-vue/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-05-25
+
 ### Fixed
 
 - Button clicks are no longer swallowed by the

--- a/packages/@poupe-vue/CHANGELOG.md
+++ b/packages/@poupe-vue/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Button clicks are no longer swallowed by the
+  `.ripple-effect` utility's `pointer-events: none`. The
+  class belongs on the ripple particle `<span>`s, not the
+  Button host. `useRipple` was also bound to a
+  `display: contents` wrapper instead of the real
+  `<button>`, so its inline-style mutations were no-ops
+  and particles never rendered. Surface now exposes its
+  rendered root via `defineExpose({ rootElement })`; Button
+  forwards a template ref to Surface, binds `useRipple` to
+  the actual `<button>`, renders the particles as direct
+  children, and drops the ghost wrapper.
+
 ## [0.6.3] - 2026-05-23
 
 ### Fixed

--- a/packages/@poupe-vue/package.json
+++ b/packages/@poupe-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poupe/vue",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "description": "Vue component library for Poupe UI framework with theme customization and accessibility support",
   "author": "Alejandro Mery <amery@apptly.co>",

--- a/packages/@poupe-vue/src/components/__tests__/__snapshots__/button.spec.ts.snap
+++ b/packages/@poupe-vue/src/components/__tests__/__snapshots__/button.spec.ts.snap
@@ -1,16 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Button > should render correctly 1`] = `
-"<button class="relative surface surface-container surface-primary shape-squircle-medium shadow-none border-transparent cursor-pointer interactive-surface-primary inline-flex items-center justify-center gap-2 transition-all duration-200 select-none font-medium ripple-effect text-sm h-10 px-6">
-  <div class="contents" style="position: relative; overflow: hidden;">
-    <!-- Leading icon -->
-    <!--v-if-->
-    <!-- Label --><span class="leading-none">Button label</span><!-- Default slot -->
-    <!--v-if-->
-    <!-- Trailing icon -->
-    <!--v-if-->
-    <!-- Loading indicator -->
-    <!--v-if-->
-  </div>
+"<button class="relative surface surface-container surface-primary shape-squircle-medium shadow-none border-transparent cursor-pointer interactive-surface-primary inline-flex items-center justify-center gap-2 transition-all duration-200 select-none font-medium text-sm h-10 px-6" style="position: relative; overflow: hidden;">
+  <!-- Leading icon -->
+  <!--v-if-->
+  <!-- Label --><span class="leading-none">Button label</span><!-- Default slot -->
+  <!--v-if-->
+  <!-- Trailing icon -->
+  <!--v-if-->
+  <!-- Loading indicator -->
+  <!--v-if-->
+  <!-- Ripple particles -->
 </button>"
 `;

--- a/packages/@poupe-vue/src/components/__tests__/button.spec.ts
+++ b/packages/@poupe-vue/src/components/__tests__/button.spec.ts
@@ -97,6 +97,19 @@ describe('Button', () => {
     expect(wrapper.emitted('click')).toBeTruthy();
   });
 
+  // Regression: the .ripple-effect Tailwind utility sets
+  // pointer-events:none — applying it to the host (instead of
+  // the ripple particles) silently swallows all clicks.
+  it('should not apply ripple-effect class to the host', () => {
+    const wrapper = mountWithPoupe(Button, {
+      props: { label: 'click me' },
+    });
+    const button = wrapper.find('button');
+    expect(button.classes()).not.toContain('ripple-effect');
+    const styleAttribute = button.attributes('style') ?? '';
+    expect(styleAttribute).not.toMatch(/pointer-events\s*:\s*none/);
+  });
+
   // Multiple variants combination
   it('should apply multiple variants correctly', () => {
     const props: ButtonProps = {

--- a/packages/@poupe-vue/src/components/button.vue
+++ b/packages/@poupe-vue/src/components/button.vue
@@ -107,8 +107,8 @@ declare module '../composables/use-poupe' {
 </script>
 
 <script setup lang="ts">
-/* global MouseEvent, HTMLButtonElement */
-import { computed, ref } from 'vue';
+/* global MouseEvent, HTMLButtonElement, HTMLElement */
+import { computed, onMounted, ref, useTemplateRef } from 'vue';
 import { usePoupeMergedProps, useRipple } from '../composables';
 import Icon from './icon.vue';
 import Surface from './surface.vue';
@@ -125,12 +125,17 @@ const props = computed(() =>
   usePoupeMergedProps(directProps, 'button', buttonDefaults),
 );
 
-// Button reference for ripple effect
-const buttonElement = ref<HTMLButtonElement>();
+// Bind useRipple to the rendered <button> (forwarded by Surface),
+// not to an inner wrapper — listeners + bounding-rect measurements
+// must match what the user actually clicks.
+const surfaceReference = useTemplateRef<{ rootElement: HTMLElement | undefined }>('surfaceReference');
+const buttonElement = ref<HTMLButtonElement | undefined>();
+onMounted(() => {
+  buttonElement.value = surfaceReference.value?.rootElement as HTMLButtonElement | undefined;
+});
 
-// Use ripple effect (disabled state is handled reactively)
 const isDisabled = computed(() => props.value.disabled);
-useRipple(buttonElement, {
+const { ripples, getRippleStyle } = useRipple(buttonElement, {
   disabled: isDisabled,
 });
 
@@ -237,7 +242,6 @@ const buttonClasses = computed(() => {
     'transition-all duration-200',
     'select-none',
     'font-medium',
-    'ripple-effect',
   ];
 
   // Size classes
@@ -320,47 +324,51 @@ const iconSize = computed(() => {
 
 <template>
   <Surface
+    ref="surfaceReference"
     v-bind="surfaceProps"
     tag="button"
     :class="buttonClasses"
     :disabled="props.disabled || props.loading"
     @click="emit('click', $event)"
   >
-    <div
-      ref="buttonElement"
-      class="contents"
+    <!-- Leading icon -->
+    <Icon
+      v-if="props.icon || props.iconStart"
+      :icon="props.icon || props.iconStart"
+      :class="iconSize"
+    />
+
+    <!-- Label -->
+    <span
+      v-if="computedLabel && (!props.iconButton || props.extended)"
+      class="leading-none"
     >
-      <!-- Leading icon -->
-      <Icon
-        v-if="props.icon || props.iconStart"
-        :icon="props.icon || props.iconStart"
-        :class="iconSize"
-      />
+      {{ computedLabel }}
+    </span>
 
-      <!-- Label -->
-      <span
-        v-if="computedLabel && (!props.iconButton || props.extended)"
-        class="leading-none"
-      >
-        {{ computedLabel }}
-      </span>
+    <!-- Default slot -->
+    <slot v-if="!computedLabel && !props.iconButton" />
 
-      <!-- Default slot -->
-      <slot v-if="!computedLabel && !props.iconButton" />
+    <!-- Trailing icon -->
+    <Icon
+      v-if="props.trailingIcon || props.iconEnd"
+      :icon="props.trailingIcon || props.iconEnd"
+      :class="iconSize"
+    />
 
-      <!-- Trailing icon -->
-      <Icon
-        v-if="props.trailingIcon || props.iconEnd"
-        :icon="props.trailingIcon || props.iconEnd"
-        :class="iconSize"
-      />
+    <!-- Loading indicator -->
+    <Icon
+      v-if="props.loading"
+      icon="svg-spinners:12-dots-scale-rotate"
+      :class="iconSize"
+    />
 
-      <!-- Loading indicator -->
-      <Icon
-        v-if="props.loading"
-        icon="svg-spinners:12-dots-scale-rotate"
-        :class="iconSize"
-      />
-    </div>
+    <!-- Ripple particles -->
+    <span
+      v-for="r in ripples"
+      :key="r.id"
+      aria-hidden="true"
+      :style="getRippleStyle(r)"
+    />
   </Surface>
 </template>

--- a/packages/@poupe-vue/src/components/surface.vue
+++ b/packages/@poupe-vue/src/components/surface.vue
@@ -150,11 +150,18 @@ declare module '../composables/use-poupe' {
 </script>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+/* global HTMLElement */
+import { computed, ref } from 'vue';
 import { usePoupeMergedProps } from '../composables';
 
 // Define props without withDefaults
 const directProps = defineProps<SurfaceProps>();
+
+// Expose the rendered root DOM element so consumers (e.g. Button)
+// can attach refs/listeners to the real <button>/<div>/... rather
+// than to a layout-invisible wrapper.
+const rootElement = ref<HTMLElement | undefined>();
+defineExpose({ rootElement });
 
 // Merge with global defaults and component defaults
 // This provides three-level merging: global defaults < component defaults < props
@@ -213,6 +220,7 @@ const classes = computed(() =>
 <template>
   <component
     :is="props.tag"
+    ref="rootElement"
     :class="classes"
   >
     <slot />


### PR DESCRIPTION
## Summary

Two independent fixes plus a Nuxt 4 cohort minor release
for `@poupe/nuxt`.

**Shape-squircle corner sizing.** `shape-squircle-*`
applied a single 200×200 SVG via `mask-image` +
`mask-size: 100% 100%`. The corner inset scaled with the
element, so a 1216×632 Card got 300+px horizontal corners
that clipped headings and edge content behind the curve.
`getSquircleStyles` now emits a 9-layer composite mask:
four corner sub-SVGs viewBox-cropped from the existing
squircle path and sized to the SHAPE_SCALE `rounded`
value (12px for medium, 50% for full), plus four solid
edge fills and one centre fill that cover the rest via
`calc(100% - 2 * <r>)`. Corner curves now hold the
intended pixel size at any element dimension.
`-webkit-mask-*` duplications drop out (Safari 15.4
baseline), SVG path floats round to 2 dp; per-utility
payload 4.2 KB → 1.8 KB.

**Button ripple wiring.** The `.ripple-effect` utility's
`pointer-events: none` was landing on the Button host
instead of the particle `<span>`s, silently swallowing
clicks. `useRipple` was also bound to a `display: contents`
wrapper so its inline-style mutations never took effect and
particles never rendered. Surface now exposes its rendered
root via `defineExpose({ rootElement })`; Button forwards
a template ref, binds `useRipple` to the real `<button>`,
renders particles inline, and drops the ghost wrapper.

### Releases

- **`@poupe/tailwindcss` v0.5.4** — squircle corner-sizing
  fix; minor agent-docs refresh picked up from #527
  (`pnpx` → `pnpm exec`).
- **`@poupe/vue` v0.6.4** — Button ripple wiring fix.
  Surface gains `defineExpose({ rootElement })` to enable
  the host-element hand-off.
- **`@poupe/nuxt` v0.5.0** — minor release wrapping the
  Nuxt 4 cohort bump that landed via #526 (peer-dep
  `nuxt ^4.0.0` + `meta.compatibility` constraint). Nuxt 3
  consumers should stay on `@poupe/nuxt@0.4.x`. Both fixes
  above flow through transparently via `workspace:^`
  resolution.

## Test plan

- [x] `pnpm precommit` green before each push (lint +
      cspell + type-check + build + tests across the
      workspace).
- [x] All 5 commits signed.
- [x] CI Build green on the prior push; re-run for the
      amended nuxt release is the first check on this PR.
- [x] Visual smoke at the `@poupe/vue` playground:
      squircle corner at 12 px on Card (no clipped
      headings); Button ripple particles render and clicks
      dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed button ripple effect to no longer swallow click interactions
  * Improved squircle shape utilities to maintain corner curves at fixed pixel sizes across all element dimensions

* **Chores**
  * Updated Nuxt module to require Nuxt 4 with dependency bumps
  * Version updates: `@poupe-nuxt` (0.5.0), `@poupe-tailwindcss` (0.5.4), `@poupe-vue` (0.6.4)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poupe-ui/poupe/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->